### PR TITLE
libretro: Fix video being broken with Vulkan

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -284,7 +284,7 @@ void retro_run(void)
    else
       frames = 0;
 
-   video_cb(frame_buf, VIDEO_WIDTH, VIDEO_HEIGHT, 0);
+   video_cb(frame_buf, VIDEO_WIDTH, VIDEO_HEIGHT, VIDEO_WIDTH * sizeof(uint32_t));
 }
 
 bool retro_load_game(const struct retro_game_info *info)


### PR DESCRIPTION
This corrects the pitch parameter for the video refresh callback to be the actual pitch instead of 0.

Setting it to 0 seems to work fine for OpenGL, but it causes the graphics to be broken with Vulkan, at least with an AMD card on Linux.