### PR TITLE
Fix some broken shaders

### DIFF
--- a/Shaders/AAOmniScaleLegacy.fsh
+++ b/Shaders/AAOmniScaleLegacy.fsh
@@ -8,10 +8,10 @@ vec4 omniScale(sampler2D image, vec2 texCoord)
 {
     vec2 pixel = texCoord * textureDimensions - vec2(0.5, 0.5);
 
-    vec4 q11 = texture(image, vec2(floor(pixel.x) / textureDimensions.x, floor(pixel.y) / textureDimensions.y));
-    vec4 q12 = texture(image, vec2(floor(pixel.x) / textureDimensions.x, ceil(pixel.y) / textureDimensions.y));
-    vec4 q21 = texture(image, vec2(ceil(pixel.x) / textureDimensions.x, floor(pixel.y) / textureDimensions.y));
-    vec4 q22 = texture(image, vec2(ceil(pixel.x) / textureDimensions.x, ceil(pixel.y) / textureDimensions.y));
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / textureDimensions);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / textureDimensions);
 
     vec2 pos = fract(pixel);
 

--- a/Shaders/Bilinear.fsh
+++ b/Shaders/Bilinear.fsh
@@ -4,10 +4,10 @@ vec4 scale(sampler2D image)
 
     vec2 pixel = texCoord * textureDimensions - vec2(0.5, 0.5);
 
-    vec4 q11 = texture(image, vec2(floor(pixel.x) / textureDimensions.x, floor(pixel.y) / textureDimensions.y));
-    vec4 q12 = texture(image, vec2(floor(pixel.x) / textureDimensions.x, ceil(pixel.y) / textureDimensions.y));
-    vec4 q21 = texture(image, vec2(ceil(pixel.x) / textureDimensions.x, floor(pixel.y) / textureDimensions.y));
-    vec4 q22 = texture(image, vec2(ceil(pixel.x) / textureDimensions.x, ceil(pixel.y) / textureDimensions.y));
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / textureDimensions);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / textureDimensions);
 
     vec4 r1 = mix(q11, q21, fract(pixel.x));
     vec4 r2 = mix(q12, q22, fract(pixel.x));

--- a/Shaders/OmniScaleLegacy.fsh
+++ b/Shaders/OmniScaleLegacy.fsh
@@ -10,10 +10,10 @@ vec4 scale(sampler2D image)
 
     vec2 pixel = texCoord * textureDimensions - vec2(0.5, 0.5);
 
-    vec4 q11 = texture(image, (pixel                 ) / textureDimensions);
-    vec4 q12 = texture(image, (pixel + vec2(0.0, 1.0)) / textureDimensions);
-    vec4 q21 = texture(image, (pixel + vec2(1.0, 0.0)) / textureDimensions);
-    vec4 q22 = texture(image, (pixel + vec2(1.0, 1.0)) / textureDimensions);
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / textureDimensions);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / textureDimensions);
 
     vec2 pos = fract(pixel);
 

--- a/Shaders/SmoothBilinear.fsh
+++ b/Shaders/SmoothBilinear.fsh
@@ -4,10 +4,10 @@ vec4 scale(sampler2D image)
 
     vec2 pixel = texCoord * textureDimensions - vec2(0.5, 0.5);
 
-    vec4 q11 = texture(image, vec2(floor(pixel.x) / textureDimensions.x, floor(pixel.y) / textureDimensions.y));
-    vec4 q12 = texture(image, vec2(floor(pixel.x) / textureDimensions.x, ceil(pixel.y) / textureDimensions.y));
-    vec4 q21 = texture(image, vec2(ceil(pixel.x) / textureDimensions.x, floor(pixel.y) / textureDimensions.y));
-    vec4 q22 = texture(image, vec2(ceil(pixel.x) / textureDimensions.x, ceil(pixel.y) / textureDimensions.y));
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / textureDimensions);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / textureDimensions);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / textureDimensions);
 
     vec2 s = smoothstep(0., 1., fract(pixel));
 

--- a/Shaders/SmoothBilinear.fsh
+++ b/Shaders/SmoothBilinear.fsh
@@ -11,8 +11,8 @@ vec4 scale(sampler2D image)
 
     vec2 s = smoothstep(0., 1., fract(pixel));
 
-    vec4 r1 = mix(q11, q21, fract(s.x));
-    vec4 r2 = mix(q12, q22, fract(s.x));
+    vec4 r1 = mix(q11, q21, s.x);
+    vec4 r2 = mix(q12, q22, s.x);
 
-    return mix (r1, r2, fract(s.y));
+    return mix (r1, r2, s.y);
 }


### PR DESCRIPTION
This fixes Bilinear, SmoothBilinear, and AAOmniScaleLegacy so they aren't sampling at texel edges (which causes one or the other to be chosen semi-randomly, depending on rounding errors).
This also fixes issues with specific scale factors in OmniScaleLegacy and SmoothBilinear.