### PR TITLE
Core: Fix libretro builds

### DIFF
--- a/Core/gb.c
+++ b/Core/gb.c
@@ -144,7 +144,9 @@ void GB_free(GB_gameboy_t *gb)
     if (gb->breakpoints) {
         free(gb->breakpoints);
     }
+#ifndef DISABLE_DEBUGGER
     GB_debugger_clear_symbols(gb);
+#endif
     GB_rewind_free(gb);
     memset(gb, 0, sizeof(*gb));
 }


### PR DESCRIPTION
Please review this to make sure its right.

The build failure is.
```
cc -c -o ../build/obj/../libretro/dmg_boot_libretro.c.o ../libretro/dmg_boot.c -DGIT_VERSION=\"" ba07e7b"\" -DSAMEBOY_CORE_VERSION=\"\" -O2 -DNDEBUG -DDISABLE_TIMEKEEPING -DDISABLE_REWIND -DDISABLE_DEBUGGER -Wall -D__LIBRETRO__ -fPIC -I.. -std=gnu11 -D_GNU_SOURCE -D_USE_MATH_DEFINES -fPIC -DGB_INTERNAL
cc -fPIC -shared -Wl,--version-script=../libretro/link.T -Wl,--no-undefined -I.. -o ../build/bin/sameboy_libretro.so ../build/obj/../Core/gb_libretro.c.o ../build/obj/../Core/apu_libretro.c.o ../build/obj/../Core/memory_libretro.c.o ../build/obj/../Core/mbc_libretro.c.o ../build/obj/../Core/timing_libretro.c.o ../build/obj/../Core/display_libretro.c.o ../build/obj/../Core/symbol_hash_libretro.c.o ../build/obj/../Core/camera_libretro.c.o ../build/obj/../Core/z80_cpu_libretro.c.o ../build/obj/../Core/joypad_libretro.c.o ../build/obj/../Core/save_state_libretro.c.o ../build/obj/../libretro/agb_boot_libretro.c.o ../build/obj/../libretro/cgb_boot_libretro.c.o ../build/obj/../libretro/dmg_boot_libretro.c.o ../build/obj/../libretro/libretro_libretro.c.o -lm
../build/obj/../Core/gb_libretro.c.o: In function `GB_free':
gb.c:(.text+0x214): undefined reference to `GB_debugger_clear_symbols'
collect2: error: ld returned 1 exit status
make: *** [Makefile:182: ../build/bin/sameboy_libretro.so] Error 1
rm ../libretro/cgb_boot.c ../libretro/dmg_boot.c ../libretro/agb_boot.c
make: Leaving directory '/tmp/SameBoy/libretro
```
Git bisect revealed this commit.
```
ba07e7ba85606cedee791b5e96be9a808d0fba1f is the first bad commit
commit ba07e7ba85606cedee791b5e96be9a808d0fba1f
Author: Lior Halphon <LIJI32@gmail.com>
Date:   Mon Apr 2 19:57:39 2018 +0300

    Fixed a bug where 0:$dxxx reads/writes from the wrong bank in CGB mode. Made sure symbols are reset after reloading a sym file.

:040000 040000 ba79bbb963b62e5d975c7bd2adf8c336e1edd5af 5eb1daa51e7a027c09c12f31bb1b39bbbb83e561 M	Cocoa
:040000 040000 8135b0be3d8226411d4462a4b89e06f14b2a0e19 789aa29523029001172592918b1e00c534be42b3 M	Core
```
ba07e7ba85606cedee791b5e96be9a808d0fba1f