### PR TITLE
Add fullscreen mode for the SDL2 port

### DIFF
--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -76,6 +76,7 @@ static const char *help[] ={
 " Pause:             " MODIFIER_NAME "+P\n"
 " Save state:    " MODIFIER_NAME "+(0-9)\n"
 " Load state:  " MODIFIER_NAME "+" SHIFT_STRING "+(0-9)\n"
+" Toggle Fullscreen  " MODIFIER_NAME "+F\n"
 #ifdef __APPLE__
 " Mute/Unmute:     " MODIFIER_NAME "+" SHIFT_STRING "+M\n"
 #else

--- a/SDL/main.c
+++ b/SDL/main.c
@@ -202,6 +202,17 @@ static void handle_events(GB_gameboy_t *gb)
                             SDL_PauseAudio(SDL_GetAudioStatus() == SDL_AUDIO_PLAYING? true : false);
                         }
                         break;
+                    
+                    case SDL_SCANCODE_F:
+                        if (event.key.keysym.mod & MODIFIER) {
+                            if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == false) {
+                                SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+                            }
+                            else { 
+                                SDL_SetWindowFullscreen(window, 0);
+                            }
+                        }
+                        break;
                         
                     default:
                         /* Save states */


### PR DESCRIPTION
This commit implements a fullscreen mode for the SDL2 port.

Fullscreen mode is toggled with CTRL/CMD+F as described in the "Help" menu.