### PR TITLE
Fix savestates in SDL2 port

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -205,9 +205,9 @@ static void handle_events(GB_gameboy_t *gb)
                         
                     default:
                         /* Save states */
-                        if (event.key.keysym.scancode >= SDL_SCANCODE_0 && event.key.keysym.scancode <= SDL_SCANCODE_9) {
+                        if (event.key.keysym.scancode >= SDL_SCANCODE_1 && event.key.keysym.scancode <= SDL_SCANCODE_0) {
                             if (event.key.keysym.mod & MODIFIER) {
-                                command_parameter = event.key.keysym.scancode - SDL_SCANCODE_0;
+                                command_parameter = event.key.keysym.scancode - SDL_SCANCODE_1;
                                 
                                 if (event.key.keysym.mod & KMOD_SHIFT) {
                                     pending_command = GB_SDL_LOAD_STATE_COMMAND;


### PR DESCRIPTION
Because SDL_SCANCODE_0 comes *after* SDL_SCANCODE_9 in the SDL keycode
table, we have to check if the keycode is between >=1 and <=0. We also
have to substract SDL_SCANCODE_1 in order to set command_parameter
properly.

See https://wiki.libsdl.org/SDLScancodeLookup for reference.

Errata: Currently, the savestate created with CTRL+0 is created, but
refuses to load on Windows (working fine on Linux).