### PR TITLE
SDL2: Write battery file information before issueing RESET_COMMAND

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -302,6 +302,7 @@ static bool handle_pending_command(void)
         }
             
         case GB_SDL_RESET_COMMAND:
+            GB_save_battery(&gb, battery_save_path_ptr);
             return true;
             
         case GB_SDL_NO_COMMAND:


### PR DESCRIPTION
Before performing the GB reset, we should perform a GB_save_battery.

Otherwise, resetting the emulation will kill ("kill" as in simply don't
write them into the .sav) all changes made to the battery save since
sameboy was started.

I don't know how the Cocoa port handles this, maybe this should be
moved to Core/gb.c one time? Or do you prefer to get this handled
by the backends like this patch does?