### PR TITLE
SDL2: Update to SDL_OpenAudioDevice()

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -472,7 +472,7 @@ int main(int argc, char **argv)
     want_aspec.samples = 512;
 #endif
 
-#if SDL_COMPILEDVERSION > 2006 && defined(_WIN32)
+#if SDL_COMPILEDVERSION >= 2006 && defined(_WIN32)
     /* SDL 2.0.6 offers WASAPI support which allows for much lower audio buffer lengths which at least
        theoretically reduces lagging. */
     printf("SDL 2.0.6+ detected, reducing audio buffer to 32 samples\n");


### PR DESCRIPTION
Instead of the legacy SDL_OpenAudio() method, we now use the newer
SDL_OpenAudioDevice() functions. This fixes audio in Windows if the SDL
version is 2.0.6 or higher.

It also allows us to use 48kHz audio for Windows (96kHz somewhat works
too, but since we don't get absolutely smooth audio with it, I'd stick
with 48kHz for now until we find a solution. 44.1Khz is available as
fallback for SDL 2.0.5 and lower.

And finally, thanks to SDL 2.0.6+ offering support for the WASAPI audio driver,
we now can reduce the audio buffer length to 32. Might be a bit too low, so maybe
we need to increase this later on.

Yes, the 2.0.5 to 2.0.6 transition was
quite harsh in terms of Windows audio support...