### PR TITLE
Improve compatibility with the Unix tools included in Git for Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PLATFORM := windows32
 USE_WINDRES := true
 endif
 
+ifneq ($(findstring MSYS,$(PLATFORM)),)
+PLATFORM := windows32
+endif
+
 ifeq ($(PLATFORM),Darwin)
 DEFAULT := cocoa
 else


### PR DESCRIPTION
Previously the Makefile, when run on Windows, expected the uname command to report either "MINGW" or "windows32". This was unfortunate because the uname included in Git for Windows reports "MSYS".

With this change, the Makefile will work properly with any uname, whether it comes from MinGW, GnuWin32 or Git for Windows.