### PR TITLE
Use clang only if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ OBJ := build/obj
 BOOTROMS_DIR ?= $(BIN)/BootROMs
 
 # Set tools
-
-CC := clang
 ifeq ($(PLATFORM),windows32)
 # To force use of the Unix version instead of the Windows version
 MKDIR := $(shell which mkdir)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ OBJ := build/obj
 BOOTROMS_DIR ?= $(BIN)/BootROMs
 
 # Set tools
+
+# Use clang if it's available.
+ifneq (, $(shell which clang))
+CC := clang
+endif
+
 ifeq ($(PLATFORM),windows32)
 # To force use of the Unix version instead of the Windows version
 MKDIR := $(shell which mkdir)


### PR DESCRIPTION
Redefining CC isn't a standard thing to do in Makefiles. See more information about this over at:
https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html