### PR TITLE
Fix control reaches end of non-void function

### DIFF
--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -226,15 +226,15 @@ static value_t read_lvalue(GB_gameboy_t *gb, lvalue_t lvalue)
             return VALUE_16(GB_read_memory(gb, lvalue.memory_address.value) |
                             (GB_read_memory(gb, lvalue.memory_address.value + 1) * 0x100));
 
-
-        case LVALUE_REG16:
-            return VALUE_16(*lvalue.register_address);
-
         case LVALUE_REG_L:
             return VALUE_16(*lvalue.register_address & 0x00FF);
 
         case LVALUE_REG_H:
             return VALUE_16(*lvalue.register_address >> 8);
+
+        case LVALUE_REG16:
+        default:
+            return VALUE_16(*lvalue.register_address);
     }
 }
 

--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -236,7 +236,7 @@ static value_t read_lvalue(GB_gameboy_t *gb, lvalue_t lvalue)
             return VALUE_16(*lvalue.register_address >> 8);
     }
 
-    return VALUE_16(*lvalue.register_address);
+    return VALUE_16(0);
 }
 
 static void write_lvalue(GB_gameboy_t *gb, lvalue_t lvalue, uint16_t value)

--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -226,16 +226,17 @@ static value_t read_lvalue(GB_gameboy_t *gb, lvalue_t lvalue)
             return VALUE_16(GB_read_memory(gb, lvalue.memory_address.value) |
                             (GB_read_memory(gb, lvalue.memory_address.value + 1) * 0x100));
 
+        case LVALUE_REG16:
+            return VALUE_16(*lvalue.register_address);
+
         case LVALUE_REG_L:
             return VALUE_16(*lvalue.register_address & 0x00FF);
 
         case LVALUE_REG_H:
             return VALUE_16(*lvalue.register_address >> 8);
-
-        case LVALUE_REG16:
-        default:
-            return VALUE_16(*lvalue.register_address);
     }
+
+    return VALUE_16(*lvalue.register_address);
 }
 
 static void write_lvalue(GB_gameboy_t *gb, lvalue_t lvalue, uint16_t value)


### PR DESCRIPTION
This change makes it so that there is a return value when a kind doens't match. Allows -Werror=return-type to pass.

```
Core/debugger.c: In function ‘read_lvalue’:
Core/debugger.c:239:1: error: control reaches end of non-void function [-Werror=return-type]
 }
```