### PR TITLE
Fix boolean check against integer

### DIFF
--- a/Core/z80_cpu.c
+++ b/Core/z80_cpu.c
@@ -1142,7 +1142,7 @@ static void rlc_r(GB_gameboy_t *gb, uint8_t opcode)
     if (carry) {
         gb->registers[GB_REGISTER_AF] |= GB_CARRY_FLAG;
     }
-    if (!(value << 1)) {
+    if ((value << 1) != 0) {
         gb->registers[GB_REGISTER_AF] |= GB_ZERO_FLAG;
     }
 }


### PR DESCRIPTION
```
Core/z80_cpu.c: In function ‘rlc_r’:
Core/z80_cpu.c:1145:17: error: ‘<<’ in boolean context, did you mean ‘<’ ? [-Werror=int-in-bool-context]
     if (!(value << 1)) {
          ~~~~~~~^~~~~
cc1: all warnings being treated as errors
```