### PR TITLE
Fix parentheses around ‘+’ in operand of ‘&’

### DIFF
--- a/Core/z80_cpu.c
+++ b/Core/z80_cpu.c
@@ -338,7 +338,7 @@ static void add_hl_rr(GB_gameboy_t *gb, uint8_t opcode)
         gb->registers[GB_REGISTER_AF] |= GB_HALF_CARRY_FLAG;
     }
 
-    if ( ((unsigned long) hl) + ((unsigned long) rr) & 0x10000) {
+    if ( ((unsigned long) hl) + (((unsigned long) rr) & 0x10000)) {
         gb->registers[GB_REGISTER_AF] |= GB_CARRY_FLAG;
     }
 }

--- a/Core/z80_cpu.c
+++ b/Core/z80_cpu.c
@@ -338,7 +338,7 @@ static void add_hl_rr(GB_gameboy_t *gb, uint8_t opcode)
         gb->registers[GB_REGISTER_AF] |= GB_HALF_CARRY_FLAG;
     }
 
-    if ( ((unsigned long) hl) + (((unsigned long) rr) & 0x10000)) {
+    if ( ((unsigned long) hl + (unsigned long) rr) & 0x10000) {
         gb->registers[GB_REGISTER_AF] |= GB_CARRY_FLAG;
     }
 }


### PR DESCRIPTION
This fixes the parentheses around the +...

```
Core/z80_cpu.c: In function ‘add_hl_rr’:
Core/z80_cpu.c:341:31: error: suggest parentheses around ‘+’ in operand of ‘&’ [-Werror=parentheses]
     if ( ((unsigned long) hl) + ((unsigned long) rr) & 0x10000) {
          ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```

Is this the correct logic here?