### PR TITLE
Ignore multichar and int-in-bool-context warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 
 # Set compilation and linkage flags based on target, platform and configuration
 
-CFLAGS += -Werror -Wall -std=gnu11 -D_GNU_SOURCE -DVERSION="$(VERSION)" -I. -D_USE_MATH_DEFINES
+CFLAGS += -Werror -Wall -Wno-multichar -Wno-int-in-bool-context -std=gnu11 -D_GNU_SOURCE -DVERSION="$(VERSION)" -I. -D_USE_MATH_DEFINES
 SDL_LDFLAGS := -lSDL2 -lGL
 ifeq ($(PLATFORM),windows32)
 CFLAGS += -IWindows


### PR DESCRIPTION
As mentioned in https://github.com/LIJI32/SameBoy/pull/119#issuecomment-429533870 , this ignores just the two warnings that we run into on GCC. This now allows building in GCC.

@LIJI32 Thanks for the tip on ignoring just those two warnings instead of all :+1: 