### PR TITLE
Build portability

### DIFF
--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -1,5 +1,5 @@
-#include <SDL2/SDL.h>
 #include <OpenDialog/open_dialog.h>
+#include <SDL.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/SDL/gui.h
+++ b/SDL/gui.h
@@ -1,7 +1,7 @@
 #ifndef gui_h
 #define gui_h
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <Core/gb.h>
 #include <stdbool.h> 
 #include "shader.h"

--- a/SDL/main.c
+++ b/SDL/main.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <OpenDialog/open_dialog.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <Core/gb.h>
 #include "utils.h"
 #include "gui.h"

--- a/SDL/opengl_compat.c
+++ b/SDL/opengl_compat.c
@@ -1,5 +1,5 @@
 #define GL_GLEXT_PROTOTYPES
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 
 #ifndef __APPLE__
 #define GL_COMPAT_NAME(func) gl_compat_##func

--- a/SDL/opengl_compat.h
+++ b/SDL/opengl_compat.h
@@ -2,8 +2,8 @@
 #define opengl_compat_h
 
 #define GL_GLEXT_PROTOTYPES
-#include <SDL2/SDL_opengl.h>
-#include <SDL2/SDL_video.h>
+#include <SDL_opengl.h>
+#include <SDL_video.h>
 
 #ifndef __APPLE__
 #define GL_COMPAT_NAME(func) gl_compat_##func

--- a/SDL/utils.c
+++ b/SDL/utils.c
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <stdio.h>
 #include <string.h>
 #include "utils.h"


### PR DESCRIPTION
These three commits allow SameBoy to build on OpenBSD.

* On OpenBSD the compiler doesn’t look in `/usr/local` by default. `pkg-config` is used to provide whatever include directories are necessary for a library.
* SDL’s `pkg-config` files specify an include directory of `${prefix}/include/SDL2`; its headers are meant to be included relative to this directory.
* POSIX specifies the `head(1)` utility, but doesn’t specify the `-c` flag, and OpenBSD doesn’t provide one. `dd(1)` is a portable alternative.