### PR TITLE
Define random() when required with libretro

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -46,6 +46,13 @@ static const char slash = '/';
 
 #define RETRO_GAME_TYPE_GAMEBOY_LINK_2P 0x101
 
+#if !defined(ANDROID) && !defined(SWITCH)
+long random(void)
+{
+    return rand();
+}
+#endif
+
 char battery_save_path[512];
 char symbols_path[512];
 


### PR DESCRIPTION
This is part of a [patch](https://github.com/LIJI32/SameBoy/commit/8f66f11c9be45e8e291a7bec35510aeed5f16437), that for some reason was not merged upstream and is necessary for me to compile (Windows, MSVC).