### PR TITLE
Allow building with gcc.

### DIFF
--- a/Core/apu.c
+++ b/Core/apu.c
@@ -69,7 +69,9 @@ static void update_sample(GB_gameboy_t *gb, unsigned index, int8_t value, unsign
 static void render(GB_gameboy_t *gb, bool no_downsampling, GB_sample_t *dest)
 {
     GB_sample_t output = {0,0};
+#ifdef __clang__
     #pragma unroll
+#endif
     for (unsigned i = GB_N_CHANNELS; i--;) {
         double multiplier = CH_STEP;
         if (!is_DAC_enabled(gb, i)) {
@@ -126,7 +128,9 @@ static void render(GB_gameboy_t *gb, bool no_downsampling, GB_sample_t *dest)
             unsigned mask = gb->io_registers[GB_IO_NR51];
             unsigned left_volume = 0;
             unsigned right_volume = 0;
+#ifdef __clang__
             #pragma unroll
+#endif
             for (unsigned i = GB_N_CHANNELS; i--;) {
                 if (gb->apu.is_active[i]) {
                     if (mask & 1) {
@@ -374,7 +378,9 @@ void GB_apu_run(GB_gameboy_t *gb)
         }
     }
     
+#ifdef __clang__
     #pragma unroll
+#endif
     for (unsigned i = GB_SQUARE_2 + 1; i--;) {
         if (gb->apu.is_active[i]) {
             uint8_t cycles_left = cycles;

--- a/Core/display.c
+++ b/Core/display.c
@@ -27,7 +27,9 @@ static GB_fifo_item_t *fifo_pop(GB_fifo_t *fifo)
 static void fifo_push_bg_row(GB_fifo_t *fifo, uint8_t lower, uint8_t upper, uint8_t palette, bool bg_priority, bool flip_x)
 {
     if (!flip_x) {
+#ifdef __clang__
         #pragma unroll
+#endif
         for (unsigned i = 8; i--;) {
             fifo->fifo[fifo->write_end] = (GB_fifo_item_t) {
                 (lower >> 7) | ((upper >> 7) << 1),
@@ -43,7 +45,9 @@ static void fifo_push_bg_row(GB_fifo_t *fifo, uint8_t lower, uint8_t upper, uint
         }
     }
     else {
+#ifdef __clang__
         #pragma unroll
+#endif
         for (unsigned i = 8; i--;) {
             fifo->fifo[fifo->write_end] = (GB_fifo_item_t) {
                 (lower & 1) | ((upper & 1) << 1),
@@ -70,7 +74,9 @@ static void fifo_overlay_object_row(GB_fifo_t *fifo, uint8_t lower, uint8_t uppe
     
     uint8_t flip_xor = flip_x? 0: 0x7;
     
+#ifdef __clang__
     #pragma unroll
+#endif
     for (unsigned i = 8; i--;) {
         uint8_t pixel = (lower >> 7) | ((upper >> 7) << 1);
         GB_fifo_item_t *target = &fifo->fifo[(fifo->read_end + (i ^ flip_xor)) & (GB_FIFO_LENGTH - 1)];
@@ -1117,7 +1123,9 @@ uint8_t GB_get_oam_info(GB_gameboy_t *gb, GB_oam_info_t *dest, uint8_t *sprite_h
         }
 
         for (unsigned y = 0; y < *sprite_height; y++) {
+#ifdef __clang__
             #pragma unroll
+#endif
             for (unsigned x = 0; x < 8; x++) {
                 uint8_t color = (((gb->vram[vram_address    ] >> ((~x)&7)) & 1 ) |
                                  ((gb->vram[vram_address + 1] >> ((~x)&7)) & 1) << 1 );

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,10 @@ endif
 # Set tools
 
 # Use clang if it's available.
+ifeq ($(origin CC),default)
 ifneq (, $(shell which clang))
 CC := clang
+endif
 endif
 
 ifeq ($(PLATFORM),windows32)


### PR DESCRIPTION
This does two things.

1. It will respect the user set `CC` environment variable if set, it its unset it will default to `clang` like before.
2. It enables pragmas for `gcc` by checking if `__clang__` is defined. This allows building `SameBoy` with gcc without encountering `-Werror` and still allows using them with `clang`.

References:

https://stackoverflow.com/questions/18007326/how-to-change-default-values-of-variables-like-cc-in-makefile
https://stackoverflow.com/questions/28166565/detect-gcc-as-opposed-to-msvc-clang-with-macro

Also see issue https://github.com/LIJI32/SameBoy/issues/172.