### PR TITLE
Use dd instead of non-POSIX head(1) options to trim bootroms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ $(BIN)/BootROMs/%.bin: BootROMs/%.asm
 	-@$(MKDIR) -p $(dir $@)
 	cd BootROMs && rgbasm -o ../$@.tmp ../$<
 	rgblink -o $@.tmp2 $@.tmp
-	head -c $(if $(findstring dmg,$@)$(findstring sgb,$@), 256, 2304) $@.tmp2 > $@
+	dd if=$@.tmp2 of=$@ count=1 bs=$(if $(findstring dmg,$@)$(findstring sgb,$@),256,2304)
 	@rm $@.tmp $@.tmp2
 
 # Libretro Core (uses its own build system)


### PR DESCRIPTION
Splitting from #143 as this is a simpler change.

POSIX specifies the `head(1)` utility, but doesn’t specify the `-c` flag, and OpenBSD doesn’t provide one. `dd(1)` is a portable alternative.