### PR TITLE
libretro: Android update

### DIFF
--- a/libretro/jni/Application.mk
+++ b/libretro/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_STL := gnustl_static 
+APP_STL := c++_static
 APP_ABI := all

--- a/libretro/jni/Application.mk
+++ b/libretro/jni/Application.mk
@@ -1,2 +1,1 @@
-APP_STL := c++_static
 APP_ABI := all


### PR DESCRIPTION
Needed for ndk r20

I didn't realize the libretro fork only existed for the buildbot commit until after I had submitted this pr there. Once this is merged here, I'll get someone to clean up downstream.