### PR TITLE
SDL2: Write battery to disk when ROMs are hot-swapped

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -406,14 +406,12 @@ static bool handle_pending_command(void)
             return false;
         }
             
-        case GB_SDL_RESET_COMMAND:
-            GB_save_battery(&gb, battery_save_path_ptr);
-            return true;
-            
         case GB_SDL_NO_COMMAND:
             return false;
             
+        case GB_SDL_RESET_COMMAND:
         case GB_SDL_NEW_FILE_COMMAND:
+            GB_save_battery(&gb, battery_save_path_ptr);
             return true;
             
         case GB_SDL_QUIT_COMMAND:


### PR DESCRIPTION
Currently, when the emulator is reset or shutdown, the battery is written to the disk, but not when a new ROM is loaded while another is running, which can unfortunately lead to data loss.