### PR TITLE
SDL2: Fix fullscreen viewport bug

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -123,7 +123,7 @@ static void handle_events(GB_gameboy_t *gb)
             }
                 
             case SDL_WINDOWEVENT: {
-                if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
+                if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
                     update_viewport();
                 }
                 break;


### PR DESCRIPTION
For some reason, toggling a window's fullscreen mode is not considered a SDL_WINDOWEVENT_RESIZED event, so I changed it to a SDL_WINDOWEVENT_SIZE_CHANGED event, which ended up fixing the problem.

Fixes #206 