### PR TITLE
SDL2: Hide mouse cursor when menu is not active

### DIFF
--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -792,6 +792,7 @@ void connect_joypad(void)
 
 void run_gui(bool is_running)
 {
+    SDL_ShowCursor(SDL_ENABLE);
     connect_joypad();
     
     /* Draw the background screen */

--- a/SDL/main.c
+++ b/SDL/main.c
@@ -98,6 +98,7 @@ static void open_menu(void)
         SDL_PauseAudioDevice(device_id, 1);
     }
     run_gui(true);
+    SDL_ShowCursor(SDL_DISABLE);
     if (audio_playing) {
         SDL_ClearQueuedAudio(device_id);
         SDL_PauseAudioDevice(device_id, 0);
@@ -425,6 +426,7 @@ static bool handle_pending_command(void)
 
 static void run(void)
 {
+    SDL_ShowCursor(SDL_DISABLE);
     GB_model_t model;
     pending_command = GB_SDL_NO_COMMAND;
 restart:


### PR DESCRIPTION
Hiding the mouse cursor is more of an aesthetic change. I made sure that the mouse cursor is available if the menu is opened, but probably not in the most elegant way possible. Let me know if this needs to be changed or improved.