### PR TITLE
fix SDL build -> Windows.h include at the wrong place

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -10,9 +10,9 @@
 
 
 #ifndef _WIN32
-#include <Windows.h>
 #define AUDIO_FREQUENCY 96000
 #else
+#include <Windows.h>
 /* Windows (well, at least my VM) can't handle 96KHz sound well :( */
 
 /* felsqualle says: For SDL 2.0.6+ using the WASAPI driver, the highest freq.


### PR DESCRIPTION
I think it should be below the else branch