### PR TITLE
SDL: Increase scaling to 4x

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -623,7 +623,7 @@ int main(int argc, char **argv)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
     window = SDL_CreateWindow("SameBoy v" xstr(VERSION), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-                              160 * 2, 144 * 2, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+                              160 * 4, 144 * 4, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_SetWindowMinimumSize(window, 160, 144);
     
     if (fullscreen) {


### PR DESCRIPTION
This patch proposes a QoL improvement from my point of view.

Especially on displays with a rather hight screen resolution (HiDPI), the SameBoy window of the SDL version is really small. This patch simply increases the scaling from 2x to 4x.

Another approach could be to use something like a 3x scalier for "standard" DPI screens and 4x for HiDPI screens only, based on the DPI reported by SDL.