### PR TITLE
Add ld b, b breakpoint

### DIFF
--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -839,7 +839,7 @@ static bool softbreak(GB_gameboy_t *gb, char *arguments, char *modifiers, const 
     if (strcmp(lstrip(arguments), "on") == 0 || !strlen(lstrip(arguments))) {
         gb->has_software_breakpoints = true;
     }
-    else if(strcmp(lstrip(arguments), "off") == 0) {
+    else if (strcmp(lstrip(arguments), "off") == 0) {
         gb->has_software_breakpoints = false;
     }
     else {

--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -836,7 +836,7 @@ static bool registers(GB_gameboy_t *gb, char *arguments, char *modifiers, const 
 static bool softbreak(GB_gameboy_t *gb, char *arguments, char *modifiers, const debugger_command_t *command)
 {
     NO_MODIFIERS
-    if (strcmp(lstrip(arguments), "on") == 0) {
+    if (strcmp(lstrip(arguments), "on") == 0 || !strlen(lstrip(arguments))) {
         gb->has_software_breakpoints = true;
     }
     else if(strcmp(lstrip(arguments), "off") == 0) {

--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -832,6 +832,23 @@ static bool registers(GB_gameboy_t *gb, char *arguments, char *modifiers, const 
     return true;
 }
 
+/* Enable or disable software breakpoints */
+static bool softbreak(GB_gameboy_t *gb, char *arguments, char *modifiers, const debugger_command_t *command)
+{
+    NO_MODIFIERS
+    if (strcmp(lstrip(arguments), "on") == 0) {
+        gb->has_software_breakpoints = true;
+    }
+    else if(strcmp(lstrip(arguments), "off") == 0) {
+        gb->has_software_breakpoints = false;
+    }
+    else {
+        print_usage(gb, command);
+    }
+
+    return true;
+}
+
 /* Find the index of the closest breakpoint equal or greater to addr */
 static uint16_t find_breakpoint(GB_gameboy_t *gb, value_t addr)
 {
@@ -1780,6 +1797,7 @@ static const debugger_command_t commands[] = {
                       "a more (c)ompact one, or a one-(l)iner", "", "(f|c|l)"},
     {"lcd", 3, lcd, "Displays information about the current state of the LCD controller"},
     {"palettes", 3, palettes, "Displays the current CGB palettes"},
+    {"softbreak", 2, softbreak, "Enables or disables software breakpoints", "(on|off)"},
     {"breakpoint", 1, breakpoint, "Add a new breakpoint at the specified address/expression" HELP_NEWLINE
                                   "Can also modify the condition of existing breakpoints." HELP_NEWLINE
                                   "If the j modifier is used, the breakpoint will occur just before" HELP_NEWLINE

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -601,7 +601,7 @@ struct GB_gameboy_internal_s {
         /* Breakpoints */
         uint16_t n_breakpoints;
         struct GB_breakpoint_s *breakpoints;
-        bool has_jump_to_breakpoints;
+        bool has_jump_to_breakpoints, has_software_breakpoints;
         void *nontrivial_jump_state;
         bool non_trivial_jump_breakpoint_occured;
 

--- a/Core/sm83_cpu.c
+++ b/Core/sm83_cpu.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <assert.h>
+#include "debugger.h"
 #include "gb.h"
 
 
@@ -789,6 +790,11 @@ LD_X_Y(l,b) LD_X_Y(l,c) LD_X_Y(l,d) LD_X_Y(l,e) LD_X_Y(l,h)             LD_X_DHL
 LD_DHL_Y(b) LD_DHL_Y(c) LD_DHL_Y(d) LD_DHL_Y(e) LD_DHL_Y(h) LD_DHL_Y(l)             LD_DHL_Y(a)
 LD_X_Y(a,b) LD_X_Y(a,c) LD_X_Y(a,d) LD_X_Y(a,e) LD_X_Y(a,h) LD_X_Y(a,l) LD_X_DHL(a)
 
+// simply fire the debugger
+static void ld_b_b(GB_gameboy_t *gb, uint8_t opcode)
+{
+    GB_debugger_break(gb);
+}
 
 static void add_a_r(GB_gameboy_t *gb, uint8_t opcode)
 {
@@ -1462,7 +1468,7 @@ static GB_opcode_t *opcodes[256] = {
     jr_cc_r8,   add_hl_rr,  ld_a_dhli,  dec_rr,     inc_lr,     dec_lr,     ld_lr_d8,   cpl,
     jr_cc_r8,   ld_rr_d16,  ld_dhld_a,  inc_rr,     inc_dhl,    dec_dhl,    ld_dhl_d8,  scf,        /* 3X */
     jr_cc_r8,   add_hl_rr,  ld_a_dhld,  dec_rr,     inc_hr,     dec_hr,     ld_hr_d8,   ccf,
-    nop,        ld_b_c,     ld_b_d,     ld_b_e,     ld_b_h,     ld_b_l,     ld_b_dhl,   ld_b_a,     /* 4X */
+    ld_b_b,     ld_b_c,     ld_b_d,     ld_b_e,     ld_b_h,     ld_b_l,     ld_b_dhl,   ld_b_a,     /* 4X */
     ld_c_b,     nop,        ld_c_d,     ld_c_e,     ld_c_h,     ld_c_l,     ld_c_dhl,   ld_c_a,
     ld_d_b,     ld_d_c,     nop,        ld_d_e,     ld_d_h,     ld_d_l,     ld_d_dhl,   ld_d_a,     /* 5X */
     ld_e_b,     ld_e_c,     ld_e_d,     nop,        ld_e_h,     ld_e_l,     ld_e_dhl,   ld_e_a,

--- a/Core/sm83_cpu.c
+++ b/Core/sm83_cpu.c
@@ -790,10 +790,12 @@ LD_X_Y(l,b) LD_X_Y(l,c) LD_X_Y(l,d) LD_X_Y(l,e) LD_X_Y(l,h)             LD_X_DHL
 LD_DHL_Y(b) LD_DHL_Y(c) LD_DHL_Y(d) LD_DHL_Y(e) LD_DHL_Y(h) LD_DHL_Y(l)             LD_DHL_Y(a)
 LD_X_Y(a,b) LD_X_Y(a,c) LD_X_Y(a,d) LD_X_Y(a,e) LD_X_Y(a,h) LD_X_Y(a,l) LD_X_DHL(a)
 
-// simply fire the debugger
+// fire the debugger if software breakpoints are enabled
 static void ld_b_b(GB_gameboy_t *gb, uint8_t opcode)
 {
-    GB_debugger_break(gb);
+    if(gb->has_software_breakpoints) {
+        GB_debugger_break(gb);
+    }
 }
 
 static void add_a_r(GB_gameboy_t *gb, uint8_t opcode)

--- a/Core/sm83_cpu.c
+++ b/Core/sm83_cpu.c
@@ -793,7 +793,7 @@ LD_X_Y(a,b) LD_X_Y(a,c) LD_X_Y(a,d) LD_X_Y(a,e) LD_X_Y(a,h) LD_X_Y(a,l) LD_X_DHL
 // fire the debugger if software breakpoints are enabled
 static void ld_b_b(GB_gameboy_t *gb, uint8_t opcode)
 {
-    if(gb->has_software_breakpoints) {
+    if (gb->has_software_breakpoints) {
         GB_debugger_break(gb);
     }
 }


### PR DESCRIPTION
This is a fairly basic change. Just fire the debugger when `ld b, b` is encountered.

Signed-off-by: James Larrowe <larrowe.semaj11@gmail.com>