### PR TITLE
Add basic support for 16-bit color output (not tested)

### DIFF
--- a/Core/display.c
+++ b/Core/display.c
@@ -131,7 +131,7 @@ static void display_vblank(GB_gameboy_t *gb)
     if (!gb->disable_rendering  && ((!(gb->io_registers[GB_IO_LCDC] & 0x80) || is_ppu_stopped) || gb->cgb_repeated_a_frame)) {
         /* LCD is off, set screen to white or black (if LCD is on in stop mode) */
         if (!GB_is_sgb(gb)) {
-            uint32_t color = 0;
+            GB_output_color_t color = 0;
             if (GB_is_cgb(gb)) {
                 color = GB_convert_rgb15(gb, 0x7FFF, false);
             }
@@ -157,7 +157,7 @@ static void display_vblank(GB_gameboy_t *gb)
     
     if (gb->border_mode == GB_BORDER_ALWAYS && !GB_is_sgb(gb)) {
         GB_borrow_sgb_border(gb);
-        uint32_t border_colors[16 * 4];
+        GB_output_color_t border_colors[16 * 4];
         
         if (!gb->has_sgb_border && GB_is_cgb(gb) && gb->model != GB_MODEL_AGB) {
             static uint16_t colors[] = {
@@ -188,7 +188,7 @@ static void display_vblank(GB_gameboy_t *gb)
                 for (unsigned y = 0; y < 8; y++) {
                     for (unsigned x = 0; x < 8; x++) {
                         uint8_t color = gb->borrowed_border.tiles[(tile & 0xFF) * 64 + (x ^ flip_x) + (y ^ flip_y) * 8] & 0xF;
-                        uint32_t *output = gb->screen + tile_x * 8 + x + (tile_y * 8 + y) * 256;
+                        GB_output_color_t *output = gb->screen + tile_x * 8 + x + (tile_y * 8 + y) * 256;
                         if (color == 0) {
                             *output = border_colors[0];
                         }
@@ -229,7 +229,7 @@ static inline uint8_t scale_channel_with_curve_sgb(uint8_t x)
 }
 
 
-uint32_t GB_convert_rgb15(GB_gameboy_t *gb, uint16_t color, bool for_border)
+GB_output_color_t GB_convert_rgb15(GB_gameboy_t *gb, uint16_t color, bool for_border)
 {
     uint8_t r = (color) & 0x1F;
     uint8_t g = (color >> 5) & 0x1F;
@@ -471,7 +471,7 @@ static void render_pixel_if_possible(GB_gameboy_t *gb)
     }
 
     uint8_t icd_pixel = 0;
-    uint32_t *dest = NULL;
+    GB_output_color_t *dest = NULL;
     if (!gb->sgb) {
         if (gb->border_mode != GB_BORDER_ALWAYS) {
             dest = gb->screen + gb->lcd_x + gb->current_line * WIDTH;
@@ -1130,7 +1130,7 @@ abort_fetching_object:
             
             while (gb->lcd_x != 160 && !gb->disable_rendering && gb->screen && !gb->sgb) {
                 /* Oh no! The PPU and LCD desynced! Fill the rest of the line whith white. */
-                uint32_t *dest = NULL;
+                GB_output_color_t *dest = NULL;
                 if (gb->border_mode != GB_BORDER_ALWAYS) {
                     dest = gb->screen + gb->lcd_x + gb->current_line * WIDTH;
                 }
@@ -1302,10 +1302,10 @@ abort_fetching_object:
     }
 }
 
-void GB_draw_tileset(GB_gameboy_t *gb, uint32_t *dest, GB_palette_type_t palette_type, uint8_t palette_index)
+void GB_draw_tileset(GB_gameboy_t *gb, GB_output_color_t *dest, GB_palette_type_t palette_type, uint8_t palette_index)
 {
-    uint32_t none_palette[4];
-    uint32_t *palette = NULL;
+    GB_output_color_t none_palette[4];
+    GB_output_color_t *palette = NULL;
     
     switch (GB_is_cgb(gb)? palette_type : GB_PALETTE_NONE) {
         default:
@@ -1352,10 +1352,10 @@ void GB_draw_tileset(GB_gameboy_t *gb, uint32_t *dest, GB_palette_type_t palette
     }
 }
 
-void GB_draw_tilemap(GB_gameboy_t *gb, uint32_t *dest, GB_palette_type_t palette_type, uint8_t palette_index, GB_map_type_t map_type, GB_tileset_type_t tileset_type)
+void GB_draw_tilemap(GB_gameboy_t *gb, GB_output_color_t *dest, GB_palette_type_t palette_type, uint8_t palette_index, GB_map_type_t map_type, GB_tileset_type_t tileset_type)
 {
-    uint32_t none_palette[4];
-    uint32_t *palette = NULL;
+    GB_output_color_t none_palette[4];
+    GB_output_color_t *palette = NULL;
     uint16_t map = 0x1800;
     
     switch (GB_is_cgb(gb)? palette_type : GB_PALETTE_NONE) {

--- a/Core/display.h
+++ b/Core/display.h
@@ -39,7 +39,7 @@ typedef enum {
 } GB_tileset_type_t;
 
 typedef struct {
-    uint32_t image[128];
+    GB_output_color_t image[128];
     uint8_t x, y, tile, flags;
     uint16_t oam_addr;
     bool obscured_by_line_limit;
@@ -53,10 +53,10 @@ typedef enum {
     GB_COLOR_CORRECTION_REDUCE_CONTRAST,
 } GB_color_correction_mode_t;
 
-void GB_draw_tileset(GB_gameboy_t *gb, uint32_t *dest, GB_palette_type_t palette_type, uint8_t palette_index);
-void GB_draw_tilemap(GB_gameboy_t *gb, uint32_t *dest, GB_palette_type_t palette_type, uint8_t palette_index, GB_map_type_t map_type, GB_tileset_type_t tileset_type);
+void GB_draw_tileset(GB_gameboy_t *gb, GB_output_color_t *dest, GB_palette_type_t palette_type, uint8_t palette_index);
+void GB_draw_tilemap(GB_gameboy_t *gb, GB_output_color_t *dest, GB_palette_type_t palette_type, uint8_t palette_index, GB_map_type_t map_type, GB_tileset_type_t tileset_type);
 uint8_t GB_get_oam_info(GB_gameboy_t *gb, GB_oam_info_t *dest, uint8_t *sprite_height);
-uint32_t GB_convert_rgb15(GB_gameboy_t *gb, uint16_t color, bool for_border);
+GB_output_color_t GB_convert_rgb15(GB_gameboy_t *gb, uint16_t color, bool for_border);
 void GB_set_color_correction_mode(GB_gameboy_t *gb, GB_color_correction_mode_t mode);
 bool GB_is_odd_frame(GB_gameboy_t *gb);
 #endif /* display_h */

--- a/Core/gb.c
+++ b/Core/gb.c
@@ -991,7 +991,7 @@ uint64_t GB_run_frame(GB_gameboy_t *gb)
     return gb->cycles_since_last_sync * 1000000000LL / 2 / GB_get_clock_rate(gb); /* / 2 because we use 8MHz units */
 }
 
-void GB_set_pixels_output(GB_gameboy_t *gb, uint32_t *output)
+void GB_set_pixels_output(GB_gameboy_t *gb, GB_output_color_t *output)
 {
     gb->screen = output;
 }

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -120,6 +120,12 @@ typedef enum {
     GB_BORDER_ALWAYS,
 } GB_border_mode_t;
 
+#ifdef GB_16BIT_OUTPUT_COLOR
+typedef GB_output_color_t uint16_t
+#else
+typedef GB_output_color_t uint32_t
+#endif
+
 #define GB_MAX_IR_QUEUE 256
 
 enum {
@@ -266,7 +272,7 @@ typedef enum {
 typedef void (*GB_vblank_callback_t)(GB_gameboy_t *gb);
 typedef void (*GB_log_callback_t)(GB_gameboy_t *gb, const char *string, GB_log_attributes attributes);
 typedef char *(*GB_input_callback_t)(GB_gameboy_t *gb);
-typedef uint32_t (*GB_rgb_encode_callback_t)(GB_gameboy_t *gb, uint8_t r, uint8_t g, uint8_t b);
+typedef GB_output_color_t (*GB_rgb_encode_callback_t)(GB_gameboy_t *gb, uint8_t r, uint8_t g, uint8_t b);
 typedef void (*GB_infrared_callback_t)(GB_gameboy_t *gb, bool on, uint64_t cycles_since_last_update);
 typedef void (*GB_rumble_callback_t)(GB_gameboy_t *gb, double rumble_amplitude);
 typedef void (*GB_serial_transfer_bit_start_callback_t)(GB_gameboy_t *gb, bool bit_to_send);
@@ -755,7 +761,7 @@ void GB_set_rendering_disabled(GB_gameboy_t *gb, bool disabled);
 void GB_log(GB_gameboy_t *gb, const char *fmt, ...) __printflike(2, 3);
 void GB_attributed_log(GB_gameboy_t *gb, GB_log_attributes attributes, const char *fmt, ...) __printflike(3, 4);
 
-void GB_set_pixels_output(GB_gameboy_t *gb, uint32_t *output);
+void GB_set_pixels_output(GB_gameboy_t *gb, GB_output_color_t *output);
 void GB_set_border_mode(GB_gameboy_t *gb, GB_border_mode_t border_mode);
     
 void GB_set_infrared_input(GB_gameboy_t *gb, bool state);

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -564,9 +564,9 @@ struct GB_gameboy_internal_s {
         uint8_t *mbc_ram;
 
         /* I/O */
-        uint32_t *screen;
-        uint32_t background_palettes_rgb[0x20];
-        uint32_t sprite_palettes_rgb[0x20];
+        GB_output_color_t *screen;
+        GB_output_color_t background_palettes_rgb[0x20];
+        GB_output_color_t sprite_palettes_rgb[0x20];
         const GB_palette_t *dmg_palette;
         GB_color_correction_mode_t color_correction_mode;
         bool keys[4][GB_KEY_MAX];

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -120,12 +120,6 @@ typedef enum {
     GB_BORDER_ALWAYS,
 } GB_border_mode_t;
 
-#ifdef GB_16BIT_OUTPUT_COLOR
-typedef GB_output_color_t uint16_t
-#else
-typedef GB_output_color_t uint32_t
-#endif
-
 #define GB_MAX_IR_QUEUE 256
 
 enum {

--- a/Core/gb_struct_def.h
+++ b/Core/gb_struct_def.h
@@ -1,5 +1,12 @@
 #ifndef gb_struct_def_h
 #define gb_struct_def_h
+#include <stdint.h>
 struct GB_gameboy_s;
 typedef struct GB_gameboy_s GB_gameboy_t;
+
+#ifdef GB_16BIT_OUTPUT_COLOR
+typedef uint16_t GB_output_color_t;
+#else
+typedef uint32_t GB_output_color_t;
+#endif
 #endif 

--- a/Core/printer.c
+++ b/Core/printer.c
@@ -21,9 +21,9 @@ static void handle_command(GB_gameboy_t *gb)
         case GB_PRINTER_START_COMMAND:
             if (gb->printer.command_length == 4) {
                 gb->printer.status = 6; /* Printing */
-                uint32_t image[gb->printer.image_offset];
+                GB_output_color_t image[gb->printer.image_offset];
                 uint8_t palette = gb->printer.command_data[2];
-                uint32_t colors[4] = {gb->rgb_encode_callback(gb, 0xff, 0xff, 0xff),
+                GB_output_color_t colors[4] = {gb->rgb_encode_callback(gb, 0xff, 0xff, 0xff),
                                       gb->rgb_encode_callback(gb, 0xaa, 0xaa, 0xaa),
                                       gb->rgb_encode_callback(gb, 0x55, 0x55, 0x55),
                                       gb->rgb_encode_callback(gb, 0x00, 0x00, 0x00)};

--- a/Core/printer.h
+++ b/Core/printer.h
@@ -7,7 +7,7 @@
 #define GB_PRINTER_DATA_SIZE 0x280
 
 typedef void (*GB_print_image_callback_t)(GB_gameboy_t *gb,
-                                          uint32_t *image,
+                                          GB_output_color_t *image,
                                           uint8_t height,
                                           uint8_t top_margin,
                                           uint8_t bottom_margin,

--- a/Core/sgb.c
+++ b/Core/sgb.c
@@ -519,12 +519,12 @@ void GB_sgb_write(GB_gameboy_t *gb, uint8_t value)
     }
 }
 
-static uint32_t convert_rgb15(GB_gameboy_t *gb, uint16_t color)
+static GB_output_color_t convert_rgb15(GB_gameboy_t *gb, uint16_t color)
 {
     return GB_convert_rgb15(gb, color, false);
 }
 
-static uint32_t convert_rgb15_with_fade(GB_gameboy_t *gb, uint16_t color, uint8_t fade)
+static GB_output_color_t convert_rgb15_with_fade(GB_gameboy_t *gb, uint16_t color, uint8_t fade)
 {
     uint8_t r = ((color) & 0x1F) - fade;
     uint8_t g = ((color >> 5) & 0x1F) - fade;
@@ -543,7 +543,7 @@ static uint32_t convert_rgb15_with_fade(GB_gameboy_t *gb, uint16_t color, uint8_
 static void render_boot_animation (GB_gameboy_t *gb)
 {
 #include "graphics/sgb_animation_logo.inc"
-    uint32_t *output = gb->screen;
+    GB_output_color_t *output = gb->screen;
     if (gb->border_mode != GB_BORDER_NEVER) {
         output += 48 + 40 * 256;
     }
@@ -559,7 +559,7 @@ static void render_boot_animation (GB_gameboy_t *gb)
     else if (gb->sgb->intro_animation > INTRO_ANIMATION_LENGTH - 32) {
         fade_red = fade_blue = gb->sgb->intro_animation - INTRO_ANIMATION_LENGTH + 32;
     }
-    uint32_t colors[] = {
+    GB_output_color_t colors[] = {
         convert_rgb15(gb, 0),
         convert_rgb15_with_fade(gb, 0x14A5, fade_blue),
         convert_rgb15_with_fade(gb, 0x54E0, fade_blue),
@@ -672,7 +672,7 @@ void GB_sgb_render(GB_gameboy_t *gb)
     
     if (!gb->screen || !gb->rgb_encode_callback || gb->disable_rendering) return;
 
-    uint32_t colors[4 * 4];
+    GB_output_color_t colors[4 * 4];
     for (unsigned i = 0; i < 4 * 4; i++) {
         colors[i] = convert_rgb15(gb, gb->sgb->effective_palettes[i]);
     }
@@ -687,7 +687,7 @@ void GB_sgb_render(GB_gameboy_t *gb)
         render_boot_animation(gb);
     }
     else {
-        uint32_t *output = gb->screen;
+        GB_output_color_t *output = gb->screen;
         if (gb->border_mode != GB_BORDER_NEVER) {
             output += 48 + 40 * 256;
         }
@@ -708,7 +708,7 @@ void GB_sgb_render(GB_gameboy_t *gb)
             }
             case MASK_BLACK:
             {
-                uint32_t black = convert_rgb15(gb, 0);
+                GB_output_color_t black = convert_rgb15(gb, 0);
                 for (unsigned y = 0; y < 144; y++) {
                     for (unsigned x = 0; x < 160; x++) {
                         *(output++) = black;
@@ -734,7 +734,7 @@ void GB_sgb_render(GB_gameboy_t *gb)
         }
     }
     
-    uint32_t border_colors[16 * 4];
+    GB_output_color_t border_colors[16 * 4];
     if (gb->sgb->border_animation == 0 || gb->sgb->intro_animation < INTRO_ANIMATION_LENGTH) {
         for (unsigned i = 0; i < 16 * 4; i++) {
             border_colors[i] = convert_rgb15(gb, gb->sgb->border.palette[i]);
@@ -774,7 +774,7 @@ void GB_sgb_render(GB_gameboy_t *gb)
             for (unsigned y = 0; y < 8; y++) {
                 for (unsigned x = 0; x < 8; x++) {
                     uint8_t color = gb->sgb->border.tiles[(tile & 0xFF) * 64 + (x ^ flip_x) + (y ^ flip_y) * 8] & 0xF;
-                    uint32_t *output = gb->screen;
+                    GB_output_color_t *output = gb->screen;
                     if (gb->border_mode == GB_BORDER_NEVER) {
                         output += (tile_x - 6) * 8 + x + ((tile_y - 5) * 8 + y) * 160;
                     }


### PR DESCRIPTION
Just a quick thing I tried to do. As mentioned in the title, not tested. Please review this if you have time.

As for why, I'm currently trying to port SameBoy onto microcontroller and buffer of `uint32_t` is a serious waste of memory, especially considering that actual color is 16-bit value anyways.

I'm not familiar with internals of SameBoy, so I might have either missed something or changed something I shouldn't had.