### PR TITLE
Compatibility hacks for old compilers

### DIFF
--- a/Core/gb.h
+++ b/Core/gb.h
@@ -52,6 +52,10 @@
 #error Unable to detect endianess
 #endif
 
+#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#define __builtin_bswap16(x) ({ typeof(x) _x = (x); _x >> 8 | _x << 8; })
+#endif
+
 typedef struct {
     struct {
         uint8_t r, g, b;

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ $(OBJ)/BootROMs/SameBoyLogo.pb12: $(OBJ)/BootROMs/SameBoyLogo.2bpp $(PB12_COMPRE
 	$(realpath $(PB12_COMPRESS)) < $< > $@
 	
 $(PB12_COMPRESS): BootROMs/pb12.c
-	$(NATIVE_CC) -Wall -Werror $< -o $@
+	$(NATIVE_CC) -std=c99 -Wall -Werror $< -o $@
 
 $(BIN)/BootROMs/agb_boot.bin: BootROMs/cgb_boot.asm
 $(BIN)/BootROMs/cgb_boot_fast.bin: BootROMs/cgb_boot.asm


### PR DESCRIPTION
GCC versions below 4.8.1 didn't have __builtin_bswap16, so provide
a suitable replacement.