### PR TITLE
Fix `make: write error` on macOS when `make CONF=native_release` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ ifeq ($(CONF), release)
 endif
 
 $(BIN)/SameBoy.app/Contents/Resources/Base.lproj/%.nib: Cocoa/%.xib
-	ibtool --compile $@ $^
+	ibtool --compile $@ $^ 2>&1 | cat -
 	
 # Quick Look generator
 


### PR DESCRIPTION
`ibtool` calls in macOS switch to nonblocking mode always (using make CONF=debug and make CONF=release too), but only makes `make` crash when CONF=native_release.

Running `cat` afterwards fixes it.