### PR TITLE
Quiet some deprecated warnings.

### DIFF
--- a/Cocoa/Document.h
+++ b/Cocoa/Document.h
@@ -39,7 +39,7 @@
 
 -(uint8_t) readMemory:(uint16_t) addr;
 -(void) writeMemory:(uint16_t) addr value:(uint8_t)value;
--(void) performAtomicBlock: (void (^)())block;
+-(void) performAtomicBlock: (void (^ NS_NOESCAPE)(void))block;
 
 @end
 

--- a/Cocoa/GBCheatWindowController.m
+++ b/Cocoa/GBCheatWindowController.m
@@ -135,7 +135,7 @@
 
     size_t cheatCount;
     const GB_cheat_t *const *cheats = GB_get_cheats(gb, &cheatCount);
-    unsigned row = self.cheatsTable.selectedRow;
+    NSInteger row = self.cheatsTable.selectedRow;
     const GB_cheat_t *cheat = NULL;
     if (row >= cheatCount) {
         static const GB_cheat_t template = {
@@ -203,7 +203,7 @@
     
     size_t cheatCount;
     const GB_cheat_t *const *cheats = GB_get_cheats(gb, &cheatCount);
-    unsigned row = self.cheatsTable.selectedRow;
+    NSInteger row = self.cheatsTable.selectedRow;
     
     [self.document performAtomicBlock:^{
         if (row >= cheatCount) {

--- a/Cocoa/GBImageCell.m
+++ b/Cocoa/GBImageCell.m
@@ -3,7 +3,7 @@
 @implementation GBImageCell
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
-    CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
+	CGContextRef context = [[NSGraphicsContext currentContext] CGContext];
     CGContextSetInterpolationQuality(context, kCGInterpolationNone);
     [super drawWithFrame:cellFrame inView:controlView];
 }

--- a/Cocoa/GBImageView.m
+++ b/Cocoa/GBImageView.m
@@ -16,7 +16,7 @@
 }
 - (void)drawRect:(NSRect)dirtyRect
 {
-    CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
+	CGContextRef context = [[NSGraphicsContext currentContext] CGContext];
     CGContextSetInterpolationQuality(context, kCGInterpolationNone);
     [super drawRect:dirtyRect];
     CGFloat y_ratio = self.frame.size.height / self.image.size.height;
@@ -76,19 +76,19 @@
 - (void)setHorizontalGrids:(NSArray *)horizontalGrids
 {
     self->_horizontalGrids = horizontalGrids;
-    [self setNeedsDisplay];
+	[self setNeedsDisplay:YES];
 }
 
 - (void)setVerticalGrids:(NSArray *)verticalGrids
 {
     self->_verticalGrids = verticalGrids;
-    [self setNeedsDisplay];
+	[self setNeedsDisplay:YES];
 }
 
 - (void)setDisplayScrollRect:(bool)displayScrollRect
 {
     self->_displayScrollRect = displayScrollRect;
-    [self setNeedsDisplay];
+	[self setNeedsDisplay:YES];
 }
 
 - (void)updateTrackingAreas

--- a/Cocoa/GBPreferencesWindow.m
+++ b/Cocoa/GBPreferencesWindow.m
@@ -260,13 +260,13 @@
 
 - (IBAction)changeAnalogControls:(id)sender
 {
-    [[NSUserDefaults standardUserDefaults] setBool: [(NSButton *)sender state] == NSOnState
+    [[NSUserDefaults standardUserDefaults] setBool: [(NSButton *)sender state] == NSControlStateValueOn
                                             forKey:@"GBAnalogControls"];
 }
 
 - (IBAction)changeAspectRatio:(id)sender
 {
-    [[NSUserDefaults standardUserDefaults] setBool: [(NSButton *)sender state] != NSOnState
+    [[NSUserDefaults standardUserDefaults] setBool: [(NSButton *)sender state] != NSControlStateValueOn
                                             forKey:@"GBAspectRatioUnkept"];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"GBAspectChanged" object:nil];
 }

--- a/Cocoa/GBViewMetal.h
+++ b/Cocoa/GBViewMetal.h
@@ -3,5 +3,5 @@
 #import "GBView.h"
 
 @interface GBViewMetal : GBView<MTKViewDelegate>
-+ (bool) isSupported;
++ (BOOL) isSupported;
 @end

--- a/Cocoa/GBViewMetal.m
+++ b/Cocoa/GBViewMetal.m
@@ -22,10 +22,10 @@ static const vector_float2 rect[] =
     vector_float2 output_resolution;
 }
 
-+ (bool)isSupported
++ (BOOL)isSupported
 {
     if (MTLCopyAllDevices) {
-        return [MTLCopyAllDevices() count];
+        return [MTLCopyAllDevices() count] != 0;
     }
     return false;
 }


### PR DESCRIPTION
This will quiet some deprecated warnings in regards to Cocoa methods, including:
* NSDocument hates NSString-based path methods: initial work on migrating to NSURL-based methods.
* replace `-[NSGraphicsContext graphicsPort]` with `-[NSGraphicsContext CGContext]`.

Note that I used tabs instead of spaces. I'll probably fix it in another commit.