### PR TITLE
Cartridge patch

### DIFF
--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -1533,7 +1533,7 @@ static bool mbc(GB_gameboy_t *gb, char *arguments, char *modifiers, const debugg
     const GB_cartridge_t *cartridge = gb->cartridge_type;
 
     if (cartridge->has_ram) {
-        GB_log(gb, "Cartrdige includes%s RAM: $%x bytes\n", cartridge->has_battery? " battery-backed": "", gb->mbc_ram_size);
+        GB_log(gb, "Cartridge includes%s RAM: $%x bytes\n", cartridge->has_battery? " battery-backed": "", gb->mbc_ram_size);
     }
     else {
         GB_log(gb, "No cartridge RAM\n");

--- a/QuickLook/generator.m
+++ b/QuickLook/generator.m
@@ -61,9 +61,9 @@ static OSStatus render(CGContextRef cgContext, CFURLRef url, bool showBorder)
     }
     
     if (showBorder) {
-        /* Use the CGB flag to determine the cartrdige "look":
+        /* Use the CGB flag to determine the cartridge "look":
          - DMG cartridges are grey
-         - CGB cartrdiges are transparent
+         - CGB cartridges are transparent
          - CGB cartridges that support DMG systems are black
          */
         NSImage *effectiveTemplate = nil;


### PR DESCRIPTION
These two commits just fix the word "cartridge" that was misspelled in the code. 