### PR TITLE
Windows Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,7 @@ $(OBJ)/BootROMs/SameBoyLogo.pb12: $(OBJ)/BootROMs/SameBoyLogo.2bpp $(PB12_COMPRE
 	$(realpath $(PB12_COMPRESS)) < $< > $@
 	
 $(PB12_COMPRESS): BootROMs/pb12.c
-	$(NATIVE_CC) -std=c99 -Wall -Werror $< -o $@ --target=i386-pc-windows
+	$(NATIVE_CC) -std=c99 -Wall -Werror $< -o $@
 
 $(BIN)/BootROMs/agb_boot.bin: BootROMs/cgb_boot.asm
 $(BIN)/BootROMs/cgb_boot_fast.bin: BootROMs/cgb_boot.asm

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 ifeq ($(PLATFORM),windows32)
 _ := $(shell chcp 65001)
 EXESUFFIX:=.exe
-NATIVE_CC = clang -IWindows -Wno-deprecated-declarations
+NATIVE_CC = clang -IWindows -Wno-deprecated-declarations --target=i386-pc-windows
 else
 EXESUFFIX:=
 NATIVE_CC := cc
@@ -129,8 +129,8 @@ GL_CFLAGS := $(shell $(PKG_CONFIG) --cflags gl)
 GL_LDFLAGS := $(shell $(PKG_CONFIG) --libs gl || echo -lGL)
 endif
 ifeq ($(PLATFORM),windows32)
-CFLAGS += -IWindows -Drandom=rand
-LDFLAGS += -lmsvcrt -lcomdlg32 -luser32 -lSDL2main -Wl,/MANIFESTFILE:NUL
+CFLAGS += -IWindows -Drandom=rand --target=i386-pc-windows
+LDFLAGS += -lmsvcrt -lcomdlg32 -luser32 -lshell32 -lSDL2main -Wl,/MANIFESTFILE:NUL --target=i386-pc-windows
 SDL_LDFLAGS := -lSDL2
 GL_LDFLAGS := -lopengl32
 else
@@ -404,7 +404,7 @@ $(OBJ)/BootROMs/SameBoyLogo.pb12: $(OBJ)/BootROMs/SameBoyLogo.2bpp $(PB12_COMPRE
 	$(realpath $(PB12_COMPRESS)) < $< > $@
 	
 $(PB12_COMPRESS): BootROMs/pb12.c
-	$(NATIVE_CC) -std=c99 -Wall -Werror $< -o $@
+	$(NATIVE_CC) -std=c99 -Wall -Werror $< -o $@ --target=i386-pc-windows
 
 $(BIN)/BootROMs/agb_boot.bin: BootROMs/cgb_boot.asm
 $(BIN)/BootROMs/cgb_boot_fast.bin: BootROMs/cgb_boot.asm

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SameBoy is an open-source project licensed under the MIT license, and you're wel
 SameBoy requires the following tools and libraries to build:
  * clang
  * make
- * Cocoa port: OS X SDK and Xcode command line tools [OSX Only]
+ * macOS Cocoa port: macOS SDK and Xcode (For command line tools and ibtool)
  * SDL port: libsdl2
  * [rgbds](https://github.com/bentley/rgbds/releases/), for boot ROM compilation
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SameBoy requires the following tools and libraries to build:
 On Windows, SameBoy also requires:
  * Visual Studio (For headers, etc.)
  * [GnuWin](http://gnuwin32.sourceforge.net/)
- * Running vcvars32 before running make. Make sure all required tools and libraries are in %PATH% and %lib%, respectively. (see [Build FAQ] (https://github.com/LIJI32/SameBoy/blob/master/build-faq.md))
+ * Running vcvars32 before running make. Make sure all required tools and libraries are in %PATH% and %lib%, respectively. (see [Build FAQ](https://github.com/LIJI32/SameBoy/blob/master/build-faq.md) for more details on Windows compilation)
 
 To compile, simply run `make`. The targets are `cocoa` (Default for macOS), `sdl` (Default for everything else), `libretro`, `bootroms` and `tester`. You may also specify `CONF=debug` (default), `CONF=release`, `CONF=native_release` or `CONF=fat_release`  to control optimization, symbols and multi-architectures. `native_release` is faster than `release`, but is optimized to the host's CPU and therefore is not portable. `fat_release` is exclusive to macOS and builds x86-64 and ARM64 fat binaries; this requires using a recent enough `clang` and macOS SDK using `xcode-select`, or setting them explicitly with `CC=` and `SYSROOT=`, respectively. All other configurations will build to your host architecture. You may set `BOOTROMS_DIR=...` to a directory containing precompiled boot ROM files, otherwise the build system will compile and use SameBoy's own boot ROMs.
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ SameBoy is an open-source project licensed under the MIT license, and you're wel
 SameBoy requires the following tools and libraries to build:
  * clang
  * make
- * Cocoa port: OS X SDK and Xcode command line tools
+ * Cocoa port: OS X SDK and Xcode command line tools [OSX Only]
  * SDL port: libsdl2
  * [rgbds](https://github.com/bentley/rgbds/releases/), for boot ROM compilation
 
 On Windows, SameBoy also requires:
  * Visual Studio (For headers, etc.)
  * [GnuWin](http://gnuwin32.sourceforge.net/)
- * Running vcvars32 before running make. Make sure all required tools and libraries are in %PATH% and %lib%, respectively.
+ * Running vcvars32 before running make. Make sure all required tools and libraries are in %PATH% and %lib%, respectively. (see [Build FAQ] (https://github.com/LIJI32/SameBoy/blob/master/build-faq.md))
 
 To compile, simply run `make`. The targets are `cocoa` (Default for macOS), `sdl` (Default for everything else), `libretro`, `bootroms` and `tester`. You may also specify `CONF=debug` (default), `CONF=release`, `CONF=native_release` or `CONF=fat_release`  to control optimization, symbols and multi-architectures. `native_release` is faster than `release`, but is optimized to the host's CPU and therefore is not portable. `fat_release` is exclusive to macOS and builds x86-64 and ARM64 fat binaries; this requires using a recent enough `clang` and macOS SDK using `xcode-select`, or setting them explicitly with `CC=` and `SYSROOT=`, respectively. All other configurations will build to your host architecture. You may set `BOOTROMS_DIR=...` to a directory containing precompiled boot ROM files, otherwise the build system will compile and use SameBoy's own boot ROMs.
 

--- a/build-faq.md
+++ b/build-faq.md
@@ -1,16 +1,19 @@
-# Attempting to build the Cocoa frontend fails with NSInternalInconsistencyException
+# macOS Specific Issues
+## Attempting to build the Cocoa frontend fails with NSInternalInconsistencyException
 
 When building on macOS, the build system will make a native Cocoa app by default. In this case, the build system uses the Xcode `ibtool` command to build user interface files. If this command fails, you can fix this issue by starting Xcode and letting it install components. After this is done, you should be able to close Xcode and build successfully.
 
-# Attempting to build the SDL frontend on macOS fails on linking
+## Attempting to build the SDL frontend on macOS fails on linking
 
 SameBoy on macOS expects you to have SDL2 installed via Brew, and not as a framework. Older versions expected it to be installed as a framework, but this is no longer the case.
 
-# Windows build process
+# Windows Build Process
+
+## Tools and Libraries Installation
 
 For the various tools and libraries, follow the below guide to ensure easy, proper configuration for the build environment:
 
-#### SDL Port
+### SDL2
 
 For [libSDL2](https://libsdl.org/download-2.0.php), download the Visual C++ Development Library pack. Place the extracted files within a known folder for later. Both the `\x86\` and `\include\` paths will be needed.  
 
@@ -19,17 +22,15 @@ The following examples will be referenced later:
 - `C:\SDL2\lib\x86\*`
 - `C:\SDL2\include\*`
 
-#### rgbds
+### rgbds
 
 After downloading [rgbds](https://github.com/bentley/rgbds/releases/), ensure that it is added to the `%PATH%`. This may be done by adding it to the user's or SYSTEM's Environment Variables, or may be added to the command line at compilation time via `set path=%path%;C:\path\to\rgbds`.  
 
-#### GnuWin
+### GnuWin
 
 Ensure that the `gnuwin32\bin\` directory is included in `%PATH%`. Like rgbds above, this may instead be manually included on the command line before installation: `set path=%path%;C:\path\to\gnuwin32\bin`. 
 
-If errors arise (i.e., particularly with the `CREATE_PROCESS('usr/bin/mkdir')` calls, also verify that Git for Windows has not been installed with full Linux support. If it has, remove `C:\Program Files\Git\usr\bin` from the SYSTEM %PATH% until after compilation.
-
-### Building
+## Building
 
 Within a command prompt in the project directory:
 
@@ -41,12 +42,16 @@ make
 ```
 Please note that these directories (`C:\SDL2\*`) are the examples given within the "SDL Port" section above. Ensure that your `%PATH%` properly includes `rgbds` and `gnuwin32\bin`, and that the `lib` and `include` paths include the appropriate SDL2 directories.
 
-#### Error -1073741819
+## Common Errors
+
+### Error -1073741819
 
 If encountering an error that appears as follows:
 
-> make: *** [build/bin/BootROMs/dmg_boot.bin] Error -1073741819
+``` make: *** [build/bin/BootROMs/dmg_boot.bin] Error -1073741819```
 
-Simply run `make` again, and the process will continue. This appears to happen occasionally with `build/bin/BootROMs/dmg_boot.bin` and `build/bin/BootROMs/sgb2_boot.bin`. It does not affect the compiled output.
+Simply run `make` again, and the process will continue. This appears to happen occasionally with `build/bin/BootROMs/dmg_boot.bin` and `build/bin/BootROMs/sgb2_boot.bin`. It does not affect the compiled output. This appears to be an issue with GnuWin.
 
+### The system cannot find the file specified (`usr/bin/mkdir`)
 
+If errors arise (i.e., particularly with the `CREATE_PROCESS('usr/bin/mkdir')` calls, also verify that Git for Windows has not been installed with full Linux support. If it has, remove `C:\Program Files\Git\usr\bin` from the SYSTEM %PATH% until after compilation. This happens because the Git for Windows version of `which` is used instead of the GnuWin one, and it returns a Unix-style path instead of a Windows one.

--- a/build-faq.md
+++ b/build-faq.md
@@ -5,3 +5,57 @@ When building on macOS, the build system will make a native Cocoa app by default
 # Attempting to build the SDL frontend on macOS fails on linking
 
 SameBoy on macOS expects you to have SDL2 installed via Brew, and not as a framework. Older versions expected it to be installed as a framework, but this is no longer the case.
+
+# Windows build process
+
+For the various tools and libraries, follow the below guide to ensure easy, proper configuration for the build environment:
+
+#### clang
+
+This may be installed via a Visual Studio installer packages instead of built from source.
+
+#### SDL Port
+
+[libsdl2](https://libsdl.org/download-2.0.php) has two separate files that must be downloaded
+  1. The `-x86` Runtime Binary (e.g., `SDL2-2.0.12-win32-x86.zip` (as of writing))
+  2. The Visual C++ Development Library (e.g., `SDL2-devel-2.0.12-VC.zip` (as of writing))
+
+For the Runtime Binary, place the extracted `SDL2.dll` into a known folder for later.
+
+- `C:\SDL2\bin\SDL2.dll` will be used as an example
+
+For the Visual C++ Development Library, place the extracted files within a known folder for later.
+
+The following examples will be referenced later:
+
+- `C:\SDL2\lib\x86\*`
+- `C:\SDL2\include\*`
+
+#### Gnuwin
+
+Ensure that this is in %PATH%.
+
+If errors arise (i.e., particularly with the `CREATE_PROCESS('usr/bin/mkdir')` calls, also verify that Git for Windows has not been installed with full Linux support. If it has, remove `C:\Program Files\Git\usr\bin` from the SYSTEM %PATH% until after compilation.
+
+### Building
+
+Within a command prompt in the project directory:
+
+```
+vcvars32
+set path=%path%;C:\SDL2\bin
+set lib=%lib%;C:\SDL2\lib\x86
+set include=%include%;C:\SDL2\include
+make
+```
+Please note that these directories (`C:\SDL2\*`) are the examples given within the "SDL Port" section above. Ensure that your `path`, `lib`, and `include` paths are updated appropriately with the SDL2 downloads.
+
+#### Error -1073741819
+
+If encountering an error that appears as follows:
+
+> make: *** [build/bin/BootROMs/dmg_boot.bin] Error -1073741819
+
+Simply run `make` again, and the process will continue. This appears to happen occasionally with `build/bin/BootROMs/dmg_boot.bin` and `build/bin/BootROMs/sgb2_boot.bin`. It does not affect the compiled output.
+
+

--- a/build-faq.md
+++ b/build-faq.md
@@ -10,30 +10,22 @@ SameBoy on macOS expects you to have SDL2 installed via Brew, and not as a frame
 
 For the various tools and libraries, follow the below guide to ensure easy, proper configuration for the build environment:
 
-#### clang
-
-This may be installed via a Visual Studio installer packages instead of built from source.
-
 #### SDL Port
 
-[libsdl2](https://libsdl.org/download-2.0.php) has two separate files that must be downloaded
-  1. The `-x86` Runtime Binary (e.g., `SDL2-2.0.12-win32-x86.zip` (as of writing))
-  2. The Visual C++ Development Library (e.g., `SDL2-devel-2.0.12-VC.zip` (as of writing))
+For [libSDL2](https://libsdl.org/download-2.0.php), download the Visual C++ Development Library pack. Place the extracted files within a known folder for later. Both the `\x86\` and `\include\` paths will be needed.  
 
-For the Runtime Binary, place the extracted `SDL2.dll` into a known folder for later.
-
-- `C:\SDL2\bin\SDL2.dll` will be used as an example
-
-For the Visual C++ Development Library, place the extracted files within a known folder for later.
-
-The following examples will be referenced later:
+The following examples will be referenced later: 
 
 - `C:\SDL2\lib\x86\*`
 - `C:\SDL2\include\*`
 
-#### Gnuwin
+#### rgbds
 
-Ensure that this is in %PATH%.
+After downloading [rgbds](https://github.com/bentley/rgbds/releases/), ensure that it is added to the `%PATH%`. This may be done by adding it to the user's or SYSTEM's Environment Variables, or may be added to the command line at compilation time via `set path=%path%;C:\path\to\rgbds`.  
+
+#### GnuWin
+
+Ensure that the `gnuwin32\bin\` directory is included in `%PATH%`. Like rgbds above, this may instead be manually included on the command line before installation: `set path=%path%;C:\path\to\gnuwin32\bin`. 
 
 If errors arise (i.e., particularly with the `CREATE_PROCESS('usr/bin/mkdir')` calls, also verify that Git for Windows has not been installed with full Linux support. If it has, remove `C:\Program Files\Git\usr\bin` from the SYSTEM %PATH% until after compilation.
 
@@ -43,12 +35,11 @@ Within a command prompt in the project directory:
 
 ```
 vcvars32
-set path=%path%;C:\SDL2\bin
 set lib=%lib%;C:\SDL2\lib\x86
 set include=%include%;C:\SDL2\include
 make
 ```
-Please note that these directories (`C:\SDL2\*`) are the examples given within the "SDL Port" section above. Ensure that your `path`, `lib`, and `include` paths are updated appropriately with the SDL2 downloads.
+Please note that these directories (`C:\SDL2\*`) are the examples given within the "SDL Port" section above. Ensure that your `%PATH%` properly includes `rgbds` and `gnuwin32\bin`, and that the `lib` and `include` paths include the appropriate SDL2 directories.
 
 #### Error -1073741819
 


### PR DESCRIPTION
We spoke on Reddit and you helped me get the build process working for Windows.  

I took the various extra command line arguments that we discovered were necessary with the new updates to clang (now defaults to x64 and ignores vcvars32, needs --target) and SDL2 (now needs -lshell32) and added them to the Makefile.  

Also updated the notes within build-faq.md and the readme to clarify dependencies within the Windows build process.