### PR TITLE
Update RGBDS links in README and build-faq

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SameBoy requires the following tools and libraries to build:
  * make
  * macOS Cocoa port: macOS SDK and Xcode (For command line tools and ibtool)
  * SDL port: libsdl2
- * [rgbds](https://github.com/bentley/rgbds/releases/), for boot ROM compilation
+ * [rgbds](https://github.com/gbdev/rgbds/releases/), for boot ROM compilation
 
 On Windows, SameBoy also requires:
  * Visual Studio (For headers, etc.)

--- a/build-faq.md
+++ b/build-faq.md
@@ -24,7 +24,7 @@ The following examples will be referenced later:
 
 ### rgbds
 
-After downloading [rgbds](https://github.com/bentley/rgbds/releases/), ensure that it is added to the `%PATH%`. This may be done by adding it to the user's or SYSTEM's Environment Variables, or may be added to the command line at compilation time via `set path=%path%;C:\path\to\rgbds`.  
+After downloading [rgbds](https://github.com/gbdev/rgbds/releases/), ensure that it is added to the `%PATH%`. This may be done by adding it to the user's or SYSTEM's Environment Variables, or may be added to the command line at compilation time via `set path=%path%;C:\path\to\rgbds`.  
 
 ### GnuWin
 


### PR DESCRIPTION
The repo's owner has changed twice since this link was used;
once from bentley to the neutral rednex organization, and then
from rednex to gbdev.