### PR TITLE
docs: fix simple typo, postition -> position

### DIFF
--- a/HexFiend/HFRepresenter.h
+++ b/HexFiend/HFRepresenter.h
@@ -111,7 +111,7 @@
 /// The layout position for the receiver.
 @property (nonatomic) NSPoint layoutPosition;
 
-/*! Returns the default layout position for representers of this class.  Within the -init method, the view's layout position is set to the default for this class.  You may override this to control the default layout position.  See HFLayoutRepresenter for a discussion of the significance of the layout postition.
+/*! Returns the default layout position for representers of this class.  Within the -init method, the view's layout position is set to the default for this class.  You may override this to control the default layout position.  See HFLayoutRepresenter for a discussion of the significance of the layout position.
 */
 + (NSPoint)defaultLayoutPosition;
 


### PR DESCRIPTION
There is a small typo in HexFiend/HFRepresenter.h.

Should read `position` rather than `postition`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md