### PR TITLE
Prevent shader compilation issues due to line endings on Windows machines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Always use LF line endings for shaders
+*.fsh text eol=lf
+*.metal text eol=lf
+
 HexFiend/* linguist-vendored
 *.inc linguist-language=C
 Core/*.h linguist-language=C


### PR DESCRIPTION
If the shaders do not have LF line endings then they fail to compile, which is annoying if you are developing on Windows. So I edited .gitattributes to tell git clients to always keep LF line endings for shader files.