### PR TITLE
Fix visibility of a few functions in the QuickLook plug-in.

### DIFF
--- a/QuickLook/exports.sym
+++ b/QuickLook/exports.sym
@@ -1,3 +1,1 @@
-_DeallocQuickLookGeneratorPluginType
-_QuickLookGeneratorQueryInterface
 _QuickLookGeneratorPluginFactory

--- a/QuickLook/main.c
+++ b/QuickLook/main.c
@@ -41,12 +41,12 @@ typedef struct __QuickLookGeneratorPluginType
 //	Forward declaration for the IUnknown implementation.
 //
 
-QuickLookGeneratorPluginType  *AllocQuickLookGeneratorPluginType(CFUUIDRef inFactoryID);
-void                         DeallocQuickLookGeneratorPluginType(QuickLookGeneratorPluginType *thisInstance);
-HRESULT                      QuickLookGeneratorQueryInterface(void *thisInstance, REFIID iid, LPVOID *ppv);
-void                        *QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID);
-ULONG                        QuickLookGeneratorPluginAddRef(void *thisInstance);
-ULONG                        QuickLookGeneratorPluginRelease(void *thisInstance);
+static QuickLookGeneratorPluginType  *AllocQuickLookGeneratorPluginType(CFUUIDRef inFactoryID);
+static void                         DeallocQuickLookGeneratorPluginType(QuickLookGeneratorPluginType *thisInstance);
+static HRESULT                      QuickLookGeneratorQueryInterface(void *thisInstance, REFIID iid, LPVOID *ppv);
+extern void                        *QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID);
+static ULONG                        QuickLookGeneratorPluginAddRef(void *thisInstance);
+static ULONG                        QuickLookGeneratorPluginRelease(void *thisInstance);
 
 // -----------------------------------------------------------------------------
 //	myInterfaceFtbl	definition


### PR DESCRIPTION
Only `QuickLookGeneratorPluginFactory` needs to be exposed: everything else is self-contained.