### PR TITLE
Extract CallbackBridge from Document.

### DIFF
--- a/Cocoa/CallbackBridge.h
+++ b/Cocoa/CallbackBridge.h
@@ -1,0 +1,80 @@
+#import <Foundation/Foundation.h>
+
+#include <Core/gb.h>
+
+/**
+ CallbackBridgeDelegate is implemented by objects that intend to receive events from a GB_gameboy_t using a
+ CallbackBridge.
+ */
+@protocol CallbackBridgeDelegate <NSObject>
+@required
+
+/**
+ Tells the receiver to load the given boot rom type.
+
+ The receiver is expected to invoke GB_load_boot_rom with the appropriate boot rom path.
+ */
+- (void)loadBootROM:(GB_boot_rom_t)type;
+
+@optional
+
+/**
+ Informs the receiver that the PPU has entered vblank mode.
+
+ The receiver will typically use this event to swap the pixel buffer using GB_set_pixels_output.
+ */
+- (void)vblank;
+
+- (void)log:(const char * _Nonnull)log withAttributes:(GB_log_attributes)attributes;
+- (char * _Nullable)getDebuggerInput;
+- (char * _Nullable)getAsyncDebuggerInput;
+- (uint8_t)cameraGetPixelAtX:(uint8_t)x andY:(uint8_t)y;
+- (void)cameraRequestUpdate;
+- (void)gotNewSample:(GB_sample_t * _Nonnull)sample;
+- (void)printImage:(uint32_t * _Nonnull)image
+            height:(unsigned)height
+         topMargin:(unsigned)topMargin
+      bottomMargin:(unsigned)bottomMargin
+          exposure:(unsigned)exposure;
+- (void)rumbleChanged:(double)amp;
+- (void)linkCableBitStart:(bool)bit;
+- (bool)linkCableBitEnd;
+- (void)infraredStateChanged:(bool)state;
+
+@end
+
+/**
+ A CallbackBridge can be used to connect a GB_gameboy_t's callbacks to an Objective-C instance.
+
+ An instance of this class is typically owned by the object that conforms to the CallbackBridgeDelegate protocol, and
+ that same object is provided to this instance's init method as the delegate.
+ */
+__attribute__((objc_subclassing_restricted))
+@interface CallbackBridge: NSObject
+
+/** Sets user data on gb to self and connects all applicable callbacks the delegate. */
+- (nonnull instancetype)initWithGB:(GB_gameboy_t *_Nonnull)gb delegate:(nonnull id<CallbackBridgeDelegate>)delegate;
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+/**
+ Connects gb's printer to the delegate.
+
+ The delegate must implement printImage:height:topMargin:bottomMargin:exposure: or this method will assert.
+ */
+- (void)connectPrinter;
+
+/**
+ Connects the link cable for both gb and the partnerGB to the delegate.
+
+ The delegate must implement both linkCableBitStart: and linkCableBitEnd or this method will assert.
+ */
+- (void)connectLinkCableWithPartner:(GB_gameboy_t *_Nonnull)partnerGB;
+
+/**
+ The object that implements the relevant callbacks.
+
+ Setting this value after initialization is not presently supported.
+ */
+@property (nonatomic, nullable, weak, readonly) id<CallbackBridgeDelegate> delegate;
+
+@end

--- a/Cocoa/CallbackBridge.m
+++ b/Cocoa/CallbackBridge.m
@@ -1,0 +1,145 @@
+#import "CallbackBridge.h"
+
+// MARK: - Callbacks
+
+static void boot_rom_load(GB_gameboy_t *gb, GB_boot_rom_t type)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate loadBootROM:type];
+}
+
+static void vblank(GB_gameboy_t *gb)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate vblank];
+}
+
+static void consoleLog(GB_gameboy_t *gb, const char *string, GB_log_attributes attributes)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate log:string withAttributes: attributes];
+}
+
+static char *consoleInput(GB_gameboy_t *gb)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    return [self.delegate getDebuggerInput];
+}
+
+static char *asyncConsoleInput(GB_gameboy_t *gb)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    char *ret = [self.delegate getAsyncDebuggerInput];
+    return ret;
+}
+
+static uint8_t cameraGetPixel(GB_gameboy_t *gb, uint8_t x, uint8_t y)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    return [self.delegate cameraGetPixelAtX:x andY:y];
+}
+
+static void cameraRequestUpdate(GB_gameboy_t *gb)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate cameraRequestUpdate];
+}
+
+static void printImage(GB_gameboy_t *gb, uint32_t *image, uint8_t height,
+                       uint8_t top_margin, uint8_t bottom_margin, uint8_t exposure)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate printImage:image height:height topMargin:top_margin bottomMargin:bottom_margin exposure:exposure];
+}
+
+static void audioCallback(GB_gameboy_t *gb, GB_sample_t *sample)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate gotNewSample:sample];
+}
+
+static void rumbleCallback(GB_gameboy_t *gb, double amp)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate rumbleChanged:amp];
+}
+
+static void linkCableBitStart(GB_gameboy_t *gb, bool bit_to_send)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate linkCableBitStart:bit_to_send];
+}
+
+static bool linkCableBitEnd(GB_gameboy_t *gb)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    return [self.delegate linkCableBitEnd];
+}
+
+static void infraredStateChanged(GB_gameboy_t *gb, bool on)
+{
+    CallbackBridge *self = (__bridge CallbackBridge *)GB_get_user_data(gb);
+    [self.delegate infraredStateChanged:on];
+}
+
+@implementation CallbackBridge {
+    GB_gameboy_t *_gb;
+}
+
+- (instancetype)initWithGB:(GB_gameboy_t *)gb delegate:(id<CallbackBridgeDelegate>)delegate {
+    self = [super init];
+    if (self) {
+        _gb = gb;
+        _delegate = delegate;
+
+        // Required callbacks.
+        GB_set_user_data(gb, (__bridge void *)(self));
+        GB_set_boot_rom_load_callback(gb, (GB_boot_rom_load_callback_t)boot_rom_load);
+
+        // Optional callbacks.
+        if ([delegate respondsToSelector:@selector(vblank)]) {
+            GB_set_vblank_callback(gb, (GB_vblank_callback_t)vblank);
+        }
+        if ([delegate respondsToSelector:@selector(log:withAttributes:)]) {
+            GB_set_log_callback(gb, (GB_log_callback_t)consoleLog);
+        }
+        if ([delegate respondsToSelector:@selector(getDebuggerInput)]) {
+            GB_set_input_callback(gb, (GB_input_callback_t)consoleInput);
+        }
+        if ([delegate respondsToSelector:@selector(getAsyncDebuggerInput)]) {
+        GB_set_async_input_callback(gb, (GB_input_callback_t)asyncConsoleInput);
+        }
+        if ([delegate respondsToSelector:@selector(cameraGetPixelAtX:andY:)]) {
+        GB_set_camera_get_pixel_callback(gb, cameraGetPixel);
+        }
+        if ([delegate respondsToSelector:@selector(cameraRequestUpdate)]) {
+        GB_set_camera_update_request_callback(gb, cameraRequestUpdate);
+        }
+        if ([delegate respondsToSelector:@selector(gotNewSample:)]) {
+        GB_apu_set_sample_callback(gb, audioCallback);
+        }
+        if ([delegate respondsToSelector:@selector(rumbleChanged:)]) {
+        GB_set_rumble_callback(gb, rumbleCallback);
+        }
+        if ([delegate respondsToSelector:@selector(infraredStateChanged:)]) {
+        GB_set_infrared_callback(gb, infraredStateChanged);
+        }
+    }
+    return self;
+}
+
+- (void)connectPrinter {
+    assert([_delegate respondsToSelector:@selector(printImage:height:topMargin:bottomMargin:exposure:)]);
+    GB_connect_printer(_gb, printImage);
+}
+
+- (void)connectLinkCableWithPartner:(GB_gameboy_t *)partnerGB {
+    assert([_delegate respondsToSelector:@selector(linkCableBitStart:)]
+           && [_delegate respondsToSelector:@selector(linkCableBitEnd)]);
+    GB_set_serial_transfer_bit_start_callback(_gb, linkCableBitStart);
+    GB_set_serial_transfer_bit_start_callback(partnerGB, linkCableBitStart);
+    GB_set_serial_transfer_bit_end_callback(_gb, linkCableBitEnd);
+    GB_set_serial_transfer_bit_end_callback(partnerGB, linkCableBitEnd);
+}
+
+@end


### PR DESCRIPTION
This new class enables a generalized mechanism for connecting Objective-C and Swift types to GB_gameboy_t's callback mechanisms. It has been extracted from Document.m, and Document.m now uses this type to facilitate all callbacks.

As part of this change, I've verified that no remaining references to `GB_get_user_data` exist outside of CallbackBridge.m, as the `GB_get_user_data` value has changed from a Document to a CallbackBridge.

Part of #324 