### PR TITLE
Add a pause debugger command.

### DIFF
--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -751,6 +751,19 @@ static bool cont(GB_gameboy_t *gb, char *arguments, char *modifiers, const debug
     return false;
 }
 
+static bool pause(GB_gameboy_t *gb, char *arguments, char *modifiers, const debugger_command_t *command)
+{
+    NO_MODIFIERS
+
+    if (strlen(lstrip(arguments))) {
+        print_usage(gb, command);
+        return true;
+    }
+
+    gb->debug_stopped = true;
+    return false;
+}
+
 static bool next(GB_gameboy_t *gb, char *arguments, char *modifiers, const debugger_command_t *command)
 {
     NO_MODIFIERS
@@ -1926,6 +1939,7 @@ static bool help(GB_gameboy_t *gb, char *arguments, char *modifiers, const debug
 /* Commands without implementations are aliases of the previous non-alias commands */
 static const debugger_command_t commands[] = {
     {"continue", 1, cont, "Continue running until next stop"},
+    {"pause", 1, pause, "Pause emulation immediately"},
     {"next", 1, next, "Run the next instruction, skipping over function calls"},
     {"step", 1, step, "Run the next instruction, stepping into function calls"},
     {"finish", 1, finish, "Run until the current function returns"},


### PR DESCRIPTION
This command enables the debugger to immediately pause emulation without having to set up a breakpoint. This can be useful for debugging sessions where the context isn't fully known ahead of time.