### PR TITLE
Fix broken sprite rendering in the VRAM viewer due to mis-calculation of image data size.

### DIFF
--- a/Cocoa/Document.m
+++ b/Cocoa/Document.m
@@ -1692,7 +1692,7 @@ static unsigned *multiplication_table_for_frequency(unsigned frequency)
         switch (columnIndex) {
             case 0:
                 return [Document imageFromData:[NSData dataWithBytesNoCopy:oamInfo[row].image
-                                                                    length:64 * 4
+                                                                    length:64 * 4 * 2
                                                              freeWhenDone:NO]
                                          width:8
                                         height:oamHeight


### PR DESCRIPTION
## Before

<img width="624" alt="Screen Shot 2021-01-15 at 12 41 52 AM" src="https://user-images.githubusercontent.com/45670/104686118-951cb080-56ca-11eb-968e-4778db0432c1.png">

## After

<img width="624" alt="Screen Shot 2021-01-15 at 12 42 31 AM" src="https://user-images.githubusercontent.com/45670/104686130-977f0a80-56ca-11eb-85b3-d0c594c15df5.png">
