### PR TITLE
Don't render if the emulator isn't initialized.

### DIFF
--- a/Cocoa/GBViewMetal.m
+++ b/Cocoa/GBViewMetal.m
@@ -135,6 +135,7 @@ static const vector_float2 rect[] =
 {
     if (!(view.window.occlusionState & NSWindowOcclusionStateVisible)) return;
     if (!self.gb) return;
+    if (!GB_is_inited(self.gb)) return;
     if (texture.width  != GB_get_screen_width(self.gb) ||
         texture.height != GB_get_screen_height(self.gb)) {
         [self allocateTextures];


### PR DESCRIPTION
I was encountering crashes when using the GBMetalView to show a gb instance that hadn't yet been fully initialized.