### PR TITLE
Fix for tolower extension signed char issue

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -524,9 +524,9 @@ restart:
     char extension[4] = {0,};
     if (path_length > 4) {
         if (filename[path_length - 4] == '.') {
-            extension[0] = tolower(filename[path_length - 3]);
-            extension[1] = tolower(filename[path_length - 2]);
-            extension[2] = tolower(filename[path_length - 1]);
+            extension[0] = tolower((unsigned char)filename[path_length - 3]);
+            extension[1] = tolower((unsigned char)filename[path_length - 2]);
+            extension[2] = tolower((unsigned char)filename[path_length - 1]);
         }
     }
     if (strcmp(extension, "isx") == 0) {


### PR DESCRIPTION
tolower in some build environments appears to be using the char passed in as an array index
By default the char is a signed char, which could theoretically be interpreted as a negative value.
Being a signed char this generated a warning that the compiler elevated to an error

This was an error that came about in cygwin with clang version 8.0.1