### PR TITLE
Fix off-by-one in symbol search

### DIFF
--- a/Core/symbol_hash.c
+++ b/Core/symbol_hash.c
@@ -40,7 +40,7 @@ const GB_bank_symbol_t *GB_map_find_symbol(GB_symbol_map_t *map, uint16_t addr)
 {
     if (!map) return NULL;
     size_t index = GB_map_find_symbol_index(map, addr);
-    if (index < map->n_symbols && map->symbols[index].addr != addr) {
+    if (index >= map->n_symbols || map->symbols[index].addr != addr) {
         index--;
     }
     if (index < map->n_symbols) {


### PR DESCRIPTION
Before this commit, printing an address that's after every symbol in a
bank would not show it relative to the last symbol.