### PR TITLE
add appimage build target

### DIFF
--- a/FreeDesktop/sameboy.png
+++ b/FreeDesktop/sameboy.png
@@ -1,0 +1,1 @@
+AppIcon/512x512.png

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ ifdef DATA_DIR
 CFLAGS += -DDATA_DIR="\"$(DATA_DIR)\""
 endif
 
+APPIMAGE_BUILD ?=
+
+ifdef APPIMAGE_BUILD
+CFLAGS += -DAPPIMAGE_BUILD
+endif
+
 # Set tools
 
 # Use clang if it's available.
@@ -196,6 +202,8 @@ else
 SDL_TARGET := $(BIN)/SDL/sameboy
 TESTER_TARGET := $(BIN)/tester/sameboy_tester
 endif
+
+APPIMAGE_DIR := $(BIN)/AppImage/
 
 cocoa: $(BIN)/SameBoy.app
 quicklook: $(BIN)/SameBoy.qlgenerator
@@ -457,6 +465,13 @@ else
 	-@$(MKDIR) -p $(DESTDIR)$(PREFIX)/share/applications/
 	cp FreeDesktop/sameboy.desktop $(DESTDIR)$(PREFIX)/share/applications/sameboy.desktop
 endif
+
+appimage: $(APPIMAGE_DIR)/AppDir
+	OUTPUT=$(APPIMAGE_DIR)/SameBoy.AppImage \
+	linuxdeploy --appdir $< -v2 --output appimage --desktop-file FreeDesktop/sameboy.desktop --icon-file FreeDesktop/sameboy.png
+
+$(APPIMAGE_DIR)/AppDir:
+	+make APPIMAGE_BUILD=1 DESTDIR=$@ PREFIX=/usr install
 
 $(DESTDIR)$(PREFIX)/share/icons/hicolor/%/apps/sameboy.png: FreeDesktop/AppIcon/%.png
 	-@$(MKDIR) -p $(dir $@)

--- a/SDL/utils.c
+++ b/SDL/utils.c
@@ -1,5 +1,6 @@
 #include <SDL.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include "utils.h"
@@ -25,7 +26,23 @@ char *resource_path(const char *filename)
     if (access(path, F_OK) == 0) {
         return path;
     }
-    snprintf(path, sizeof(path), "%s%s", DATA_DIR, filename);
+
+    char* directory = DATA_DIR;
+#ifdef APPIMAGE_BUILD
+    char* appdir = getenv("APPDIR");
+    if (appdir)
+    {
+        directory = malloc(strlen(DATA_DIR) + strlen(appdir) + 1);
+        strcpy(directory, appdir);
+        strcat(directory, DATA_DIR);
+    }
+#endif
+
+    snprintf(path, sizeof(path), "%s%s", directory, filename);
+
+#ifdef APPIMAGE_BUILD
+    if (appdir) free(directory);
+#endif
 #endif
     return path;
 }


### PR DESCRIPTION
This is a simple attempt at getting AppImages to work

feedback is definitely needed and I mainly wanted to get this out the door for now since this would allow for simple binary releases that target Linux.

This uses [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) which isn't package anywhere (that I am aware of) and is mainly distributed as an AppImage, so perhaps it would be better to put the tool into a variable that is definable when invoking make.

FreeDesktop/AppIcon/512x512.png has been symlinked to FreeDesktop/sameboy.png simply because the linuxdeploy needs the icon file and the icon variable in the desktop file to be the same.

the resource_path() function has been patched to check for the `APPDIR` environment variable that is specified here
https://docs.appimage.org/packaging-guide/environment-variables.html

If needed I can include a Github Actions workflow that builds an AppImage for releases

