### PR TITLE
Handle missing background.bmp

### DIFF
--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -1160,6 +1160,12 @@ void run_gui(bool is_running)
     static SDL_Surface *converted_background = NULL;
     if (!converted_background) {
         SDL_Surface *background = SDL_LoadBMP(resource_path("background.bmp"));
+        
+        /* Create a blank background if background.bmp could not be loaded */
+        if (!background) {
+            background = SDL_CreateRGBSurface(0, 160, 144, 8, 0, 0, 0, 0);
+        }
+        
         SDL_SetPaletteColors(background->format->palette, gui_palette, 0, 4);
         converted_background = SDL_ConvertSurface(background, pixel_format, 0);
         SDL_LockSurface(converted_background);


### PR DESCRIPTION
While pretty unlikely, if background.bmp ever happens to be missing, SameBoy will crash with a segmentation fault since SDL_LoadBMP returns NULL if it fails to open it.

This will instead create an empty surface with the same dimensions as background.bmp.