### PR TITLE
Match cgb boot rom duration

### DIFF
--- a/BootROMs/cgb_boot.asm
+++ b/BootROMs/cgb_boot.asm
@@ -190,10 +190,9 @@ ENDC
 IF !DEF(FAST)
     call DoIntroAnimation
 
-    ld a, 45
+    ld a, 24 ; frames to wait after playing the chime
     ldh [WaitLoopCounter], a
-; Wait ~0.75 seconds
-    ld b, a
+    ld b, 28 ; frames to wait before playing the chime
     call WaitBFrames
 
     ; Play first sound


### PR DESCRIPTION
Currently, games take a bit too long to start up, and the chime is a bit delayed.

This change will result in GB/GBC games starting up in the same amount of time. The chime will also play at the same time. While it won't appear exactly the same, it _should_ be functionally the same.

https://user-images.githubusercontent.com/39858815/135767400-2662447e-28fd-4bd1-95c2-a0df7745124a.mp4