### PR TITLE
Fix partially offscreen sprites not being returned in GB_get_oam_info

### DIFF
--- a/Core/display.c
+++ b/Core/display.c
@@ -1526,7 +1526,7 @@ uint8_t GB_get_oam_info(GB_gameboy_t *gb, GB_oam_info_t *dest, uint8_t *sprite_h
     uint8_t count = 0;
     *sprite_height = (gb->io_registers[GB_IO_LCDC] & 4) ? 16:8;
     uint8_t oam_to_dest_index[40] = {0,};
-    for (unsigned y = 0; y < LINES; y++) {
+    for (signed y = 0; y < LINES; y++) {
         GB_object_t *sprite = (GB_object_t *) &gb->oam;
         uint8_t sprites_in_line = 0;
         for (uint8_t i = 0; i < 40; i++, sprite++) {


### PR DESCRIPTION
This changes `y` from an `unsigned` value to a `signed`.

The reason this issue occurs is because of this line:
https://github.com/LIJI32/SameBoy/blob/3f954f1d0c32bd8d6fdfa00b9ff7e321c37951a6/Core/display.c#L1536

Basically, comparing a signed value against an unsigned value of the same type results in an unsigned comparison, and since sprite_y can be negative, then it underflows in this comparison.

Here is an example.

The NPC in the green shirt is partially offscreen on the top. Only the bottom half is returned (since those are separate objects):
![image](https://user-images.githubusercontent.com/39858815/138603048-631d2e3d-ffa5-434c-9a3f-6d3d0868db9b.png)

With the fix, his top half now appears:
![image](https://user-images.githubusercontent.com/39858815/138603055-4c757a77-f265-4060-88af-7e10bd9c11da.png)
