### PR TITLE
Add GB_is_cgb_in_cgb_mode

### DIFF
--- a/Core/gb.c
+++ b/Core/gb.c
@@ -1319,6 +1319,11 @@ bool GB_is_cgb(GB_gameboy_t *gb)
     return (gb->model & GB_MODEL_FAMILY_MASK) == GB_MODEL_CGB_FAMILY;
 }
 
+bool GB_is_cgb_in_cgb_mode(GB_gameboy_t *gb)
+{
+    return gb->cgb_mode;
+}
+
 bool GB_is_sgb(GB_gameboy_t *gb)
 {
     return (gb->model & ~GB_MODEL_PAL_BIT & ~GB_MODEL_NO_SFC_BIT) == GB_MODEL_SGB || (gb->model & ~GB_MODEL_NO_SFC_BIT) == GB_MODEL_SGB2;

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -763,6 +763,7 @@ __attribute__((__format__ (__printf__, fmtarg, firstvararg)))
 void GB_init(GB_gameboy_t *gb, GB_model_t model);
 bool GB_is_inited(GB_gameboy_t *gb);
 bool GB_is_cgb(GB_gameboy_t *gb);
+bool GB_is_cgb_in_cgb_mode(GB_gameboy_t *gb);
 bool GB_is_sgb(GB_gameboy_t *gb); // Returns true if the model is SGB or SGB2
 bool GB_is_hle_sgb(GB_gameboy_t *gb); // Returns true if the model is SGB or SGB2 and the SFC/SNES side is HLE'd
 GB_model_t GB_get_model(GB_gameboy_t *gb);


### PR DESCRIPTION
This exposes gb->cgb_mode in a getter function.

Basically, there is a function called GB_is_cgb, but this only returns if the core is emulating a Game Boy Color (or Game Boy Advance in CGB mode). This is helpful on its own, but it will not tell you about the type of game (DMG or CGB) running.

Having this information is important, as it allows you to know a few things:
- Is the second tileset bank valid or will I get garbage if I try to read it?
- What is the palette index of something in OAM?
- What are the number of BG and OAM palettes?

For writing a debugger that shows VRAM data, this information can be pretty useful.