### PR TITLE
gb.h: Silence -pedantic warnings

### DIFF
--- a/Core/gb.h
+++ b/Core/gb.h
@@ -368,7 +368,7 @@ struct GB_gameboy_internal_s {
         /* The version field makes sure we don't load save state files with a completely different structure.
            This happens when struct fields are removed/resized in an backward incompatible manner. */
         uint32_t version;
-    );
+    )
 
     GB_SECTION(core_state,
         /* Registers */
@@ -421,7 +421,7 @@ struct GB_gameboy_internal_s {
        int32_t ir_sensor;
        bool effective_ir_input;
        uint16_t address_bus;
-    );
+    )
 
     /* DMA and HDMA */
     GB_SECTION(dma,
@@ -437,7 +437,7 @@ struct GB_gameboy_internal_s {
         int16_t dma_cycles;
         uint8_t last_opcode_read; /* Required to emulate HDMA reads from Exxx */
         bool hdma_starting;
-    );
+    )
     
     /* MBC */
     GB_SECTION(mbc,
@@ -515,15 +515,13 @@ struct GB_gameboy_internal_s {
         uint8_t camera_registers[0x36];
         uint8_t rumble_strength;
         bool cart_ir;
-
-    );
-
+    )
 
     /* HRAM and HW Registers */
     GB_SECTION(hram,
         uint8_t hram[0xFFFF - 0xFF80];
         uint8_t io_registers[0x80];
-    );
+    )
 
     /* Timing */
     GB_SECTION(timing,
@@ -543,12 +541,12 @@ struct GB_gameboy_internal_s {
         bool lcd_disabled_outside_of_vblank;
         int32_t allowed_pending_cycles;
         uint16_t mode3_batching_length;
-    );
+    )
 
     /* APU */
     GB_SECTION(apu,
         GB_apu_t apu;
-    );
+    )
 
     /* RTC */
     GB_SECTION(rtc,
@@ -556,7 +554,7 @@ struct GB_gameboy_internal_s {
         uint64_t last_rtc_second;
         uint32_t rtc_cycles;
         uint8_t tpp1_mr4;
-    );
+    )
 
     /* Video Display */
     GB_SECTION(video,
@@ -623,7 +621,7 @@ struct GB_gameboy_internal_s {
         uint16_t last_tile_index_address;
         bool cgb_repeated_a_frame;
         uint8_t data_for_sel_glitch;
-    );
+    )
 
     /* Unsaved data. This includes all pointers, as well as everything that shouldn't be on a save state */
     /* This data is reserved on reset and must come last in the struct */
@@ -783,7 +781,7 @@ struct GB_gameboy_internal_s {
         bool disable_oam_corruption; // For safe memory reads
                
         GB_gbs_header_t gbs_header;
-   );
+   )
 };
     
 #ifndef GB_INTERNAL

--- a/Core/save_state.h
+++ b/Core/save_state.h
@@ -10,7 +10,7 @@
    as anonymous enums inside unions */
 #define GB_SECTION(name, ...) __attribute__ ((aligned (8))) __VA_ARGS__
 #else
-#define GB_SECTION(name, ...) union __attribute__ ((aligned (8))) {uint8_t name##_section_start; struct {__VA_ARGS__};}; uint8_t name##_section_end[0]
+#define GB_SECTION(name, ...) union __attribute__ ((aligned (8))) {uint8_t name##_section_start; struct {__VA_ARGS__};}; uint8_t name##_section_end[0];
 #define GB_SECTION_OFFSET(name) (offsetof(GB_gameboy_t, name##_section_start))
 #define GB_SECTION_SIZE(name) (offsetof(GB_gameboy_t, name##_section_end) - offsetof(GB_gameboy_t, name##_section_start))
 #define GB_GET_SECTION(gb, name) ((void*)&((gb)->name##_section_start))


### PR DESCRIPTION
When including `gb.h` as a dependency in a project that uses `-pedantic` there are many warnings like this. This patch will fix that without breaking the upstream SameBoy build.
```
gb.h:385:6: warning: extra ';' inside a struct [-Wextra-semi]
    );
     ^
```