### PR TITLE
Silence more -pedantic warnings

### DIFF
--- a/Core/gb.h
+++ b/Core/gb.h
@@ -44,6 +44,11 @@
 #error Unable to detect endianess
 #endif
 
+#ifdef GB_BIG_ENDIAN
+#define GB_REGISTER_ORDER a,f,b,c,d,e,h,l;
+#else
+#define GB_REGISTER_ORDER f,a,c,b,e,d,l,h;
+#endif
 
 typedef struct {
     struct GB_color_s {
@@ -335,17 +340,7 @@ typedef union {
                  pc;
     };
     struct {
-#ifdef GB_BIG_ENDIAN
-        uint8_t a, f,
-                b, c,
-                d, e,
-                h, l;
-#else
-        uint8_t f, a,
-                c, b,
-                e, d,
-                l, h;
-#endif
+        uint8_t GB_REGISTER_ORDER
     };
 } GB_registers_t;
 
@@ -383,17 +378,7 @@ struct GB_gameboy_internal_s {
                          pc;
             };
             struct {
-#ifdef GB_BIG_ENDIAN
-                uint8_t a, f,
-                        b, c,
-                        d, e,
-                        h, l;
-#else
-                uint8_t f, a,
-                        c, b,
-                        e, d,
-                        l, h;
-#endif
+                uint8_t GB_REGISTER_ORDER
             };
         };
         uint8_t ime;

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -36,6 +36,8 @@
 #define GB_MODEL_PAL_BIT 0x40
 #define GB_MODEL_NO_SFC_BIT 0x80
 
+#define GB_REWIND_FRAMES_PER_KEY 255
+
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define GB_BIG_ENDIAN
 #elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
@@ -728,7 +730,6 @@ struct GB_gameboy_internal_s {
         const char *undo_label;
 
         /* Rewind */
-#define GB_REWIND_FRAMES_PER_KEY 255
         size_t rewind_buffer_length;
         struct {
             uint8_t *key_state;


### PR DESCRIPTION
This fixes two more warnings with `-pedantic` in gb.h.

1.
```
gb.h:400:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#ifdef GB_BIG_ENDIAN
 ^
gb.h:410:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#endif
 ^
```
2.
```
gb.h:731:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#define GB_REWIND_FRAMES_PER_KEY 255
 ^
```