### PR TITLE
sgb.h: Silence -Wgnu-anonymous-struct and -Wnested-anon-type warnings

### DIFF
--- a/Core/sgb.h
+++ b/Core/sgb.h
@@ -7,6 +7,7 @@
 typedef struct GB_sgb_s GB_sgb_t;
 typedef struct {
     uint8_t tiles[0x100 * 8 * 4];
+#ifdef GB_INTERNAL
     union {
         struct {
             uint16_t map[32 * 32];
@@ -14,6 +15,9 @@ typedef struct {
         };
         uint16_t raw_data[0x440];
     };
+#else
+    uint16_t raw_data[0x440];
+#endif
 } GB_sgb_border_t;
 
 #ifdef GB_INTERNAL


### PR DESCRIPTION
When including `gb.h` as a dependency in a C++ project even with `extern "C"` warnings like this are exposed with `-pedantic`. I'm not really sure what to call this union and struct so please suggest better names if you want.
```
sgb.h:14:9: warning: anonymous structs are a GNU extension [-Wgnu-anonymous-struct]
        struct {
        ^
sgb.h:14:9: warning: anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
        struct {
        ^
```