### PR TITLE
[SDL] Fix loading of the configured DMG palette

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -831,7 +831,7 @@ int main(int argc, char **argv)
         configuration.highpass_mode %= GB_HIGHPASS_MAX;
         configuration.model %= MODEL_MAX;
         configuration.sgb_revision %= SGB_MAX;
-        configuration.dmg_palette %= 3;
+        configuration.dmg_palette %= 4;
         configuration.border_mode %= GB_BORDER_ALWAYS + 1;
         configuration.rumble_mode %= GB_RUMBLE_ALL_GAMES + 1;
         configuration.color_temperature %= 21;


### PR DESCRIPTION
There are four options for the DMG color palette:
- Greyscale
- Lime (Game Boy)
- Olive (Pocket)
- Teal (Light)

When loading the configuration from the `prefs.bin`
the configured `dmg_palette` gets normalized by applying
`mod 3` to it, limiting the possible values to [ 0, 1, 2 ],
thus selecting the “Teal” color palette will be saved as such,
but the next time the config gets loaded it gets reset to Greyscale.