### PR TITLE
Don't flash (open/close) a console on Windows

### DIFF
--- a/SDL/console.c
+++ b/SDL/console.c
@@ -85,28 +85,30 @@ static bool is_term(void)
 {
     if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) return false;
 #ifdef _WIN32
-    if (AllocConsole()) {
-        FreeConsole();
-        return false;
+    unsigned long input_mode, output_mode, has_con_input, has_con_output;
+    
+    HANDLE hSI = GetStdHandle(STD_INPUT_HANDLE);
+    HANDLE hSO = GetStdHandle(STD_OUTPUT_HANDLE);
+    
+    has_con_input = GetConsoleMode(hSI, &input_mode);
+    has_con_output = GetConsoleMode(hSO, &output_mode);
+    if (!has_con_output) {
+        return false; // stdout has been redirected to a file or pipe
     }
     
-    unsigned long input_mode, output_mode;
-    
-    GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &input_mode);
-    GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &output_mode);
-    SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), ENABLE_VIRTUAL_TERMINAL_INPUT);
-    SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+    SetConsoleMode(hSI, ENABLE_VIRTUAL_TERMINAL_INPUT);
+    SetConsoleMode(hSO, ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
     
     CONSOLE_SCREEN_BUFFER_INFO before = {0,};
-    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &before);
+    GetConsoleScreenBufferInfo(hSO, &before);
     
     printf(SGR("0"));
     
     CONSOLE_SCREEN_BUFFER_INFO after = {0,};
-    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &after);
+    GetConsoleScreenBufferInfo(hSO, &after);
     
-    SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), input_mode);
-    SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), output_mode);
+    SetConsoleMode(hSI, input_mode);
+    SetConsoleMode(hSO, output_mode);
 
 
     if (before.dwCursorPosition.X != after.dwCursorPosition.X ||
@@ -127,7 +129,7 @@ static char raw_getc(void)
 #ifdef _WIN32
     char c;
     unsigned long ret;
-    ReadConsole(GetStdHandle(STD_INPUT_HANDLE), &c, 1, &ret, NULL);
+    ReadFile(GetStdHandle(STD_INPUT_HANDLE), &c, 1, &ret, NULL);
 #else
     ssize_t ret;
     char c;


### PR DESCRIPTION
The console code tries to determine if it has a real console by calling `AllocConsole` but this will briefly show a console window in the non-debugger version. `GetConsoleMode` does not work on redirected handles, it is a much better choice.

This only checks if stdout is connected to a real console, it does not check stdin on purpose. This should in theory allow something like `sameboy_debugger.exe < commands_to_execute.txt`.