### PR TITLE
Fix random segmentation fault (fixes #442 fixes #425)

### DIFF
--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -1196,6 +1196,7 @@ void run_gui(bool is_running)
     current_selection = 0;
     scroll = 0;
     do {
+        SDL_WaitEvent(&event);
         /* Convert Joypad and mouse events (We only generate down events) */
         if (gui_state != WAITING_FOR_KEY && gui_state != WAITING_FOR_JBUTTON) {
             switch (event.type) {
@@ -1650,5 +1651,5 @@ void run_gui(bool is_running)
             render_texture(pixels, NULL);
 #endif
         }
-    } while (SDL_WaitEvent(&event));
+    } while (true);
 }

--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -1195,7 +1195,7 @@ void run_gui(bool is_running)
     recalculate_menu_height();
     current_selection = 0;
     scroll = 0;
-    do {
+    while (true) {
         SDL_WaitEvent(&event);
         /* Convert Joypad and mouse events (We only generate down events) */
         if (gui_state != WAITING_FOR_KEY && gui_state != WAITING_FOR_JBUTTON) {
@@ -1651,5 +1651,5 @@ void run_gui(bool is_running)
             render_texture(pixels, NULL);
 #endif
         }
-    } while (true);
+    }
 }


### PR DESCRIPTION
`while (SDL_WaitEvent(&event));` seems to break out of the loop when you wait a while with no input (no mouse move/clicks/keystrokes) which would cause segfault because `run_gui` would end and execution would return to main, and `run` would execute (with no rom to load).

This commit seems to fix this issue. Compiles correctly, menu works as expected, events are dispatched normally and does not segfault.