### PR TITLE
fix rlc_r zero flag

### DIFF
--- a/Core/sm83_cpu.c
+++ b/Core/sm83_cpu.c
@@ -1380,7 +1380,7 @@ static void rlc_r(GB_gameboy_t *gb, uint8_t opcode)
     if (carry) {
         gb->af |= GB_CARRY_FLAG;
     }
-    if (!(value << 1)) {
+    if (value == 0) {
         gb->af |= GB_ZERO_FLAG;
     }
 }


### PR DESCRIPTION
The comparison to set the zero flag in rlc_r discards the carry bit, it somehow worked before so maybe there's something I missed. Anyways this is slightly simpler.