### PR TITLE
Update libretro.c

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -426,7 +426,7 @@ static void init_for_current_model(unsigned id)
 
     if (GB_is_inited(&gameboy[i])) {
         GB_switch_model_and_reset(&gameboy[i], libretro_to_internal_model[effective_model]);
-		retro_set_memory_maps();
+        retro_set_memory_maps();
     }
     else {
         GB_init(&gameboy[i], libretro_to_internal_model[effective_model]);

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -426,6 +426,7 @@ static void init_for_current_model(unsigned id)
 
     if (GB_is_inited(&gameboy[i])) {
         GB_switch_model_and_reset(&gameboy[i], libretro_to_internal_model[effective_model]);
+		retro_set_memory_maps();
     }
     else {
         GB_init(&gameboy[i], libretro_to_internal_model[effective_model]);


### PR DESCRIPTION
This proposed change is to allow for the core to map the memory when initialised to allow for the memory to be usable for RetroAchievements development purposes with the core.