### PR TITLE
Fix -Werror=strict-prototypes

### DIFF
--- a/BootROMs/pb12.c
+++ b/BootROMs/pb12.c
@@ -25,7 +25,7 @@ void write_all(int fd, const void *buf, size_t count) {
     }
 }
 
-int main()
+int main(void)
 {
     static uint8_t source[0x4000];
     size_t size = read(STDIN_FILENO, &source, sizeof(source));

--- a/OpenDialog/gtk.c
+++ b/OpenDialog/gtk.c
@@ -50,7 +50,7 @@ if (symbol == NULL) symbol = dlsym(handle, #symbol);\
 if (symbol == NULL) goto lazy_error
 #define TRY_DLOPEN(name) handle = handle? handle : dlopen(name, RTLD_NOW)
 
-void nop(){}
+void nop(void){}
 
 static void wait_mouse_up(void)
 {


### PR DESCRIPTION
This will be required for upcoming gcc and clang versions.

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240