### PR TITLE
Enable loading zipped rom files

### DIFF
--- a/Core/gb.c
+++ b/Core/gb.c
@@ -10,7 +10,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_MINIZIP
+#ifdef GB_HAS_MINIZIP
 #include <minizip/unzip.h>
 #endif
 
@@ -335,7 +335,7 @@ static void init_new_rom(GB_gameboy_t *gb)
 
 int GB_load_rom(GB_gameboy_t *gb, const char *path)
 {
-#ifdef HAVE_MINIZIP
+#ifdef GB_HAS_MINIZIP
     size_t path_len = strlen(path);
     const char *ext;
     if (path_len > 4) {
@@ -373,7 +373,7 @@ int GB_load_rom_from_bin(GB_gameboy_t *gb, const char *path)
     return 0;
 }
 
-#ifdef HAVE_MINIZIP
+#ifdef GB_HAS_MINIZIP
 int GB_load_rom_from_zip(GB_gameboy_t *gb, const char *path)
 {
     GB_ASSERT_NOT_RUNNING_OTHER_THREAD(gb)

--- a/Core/gb.c
+++ b/Core/gb.c
@@ -353,19 +353,21 @@ int GB_load_rom_from_bin(GB_gameboy_t *gb, const char *path)
     GB_ASSERT_NOT_RUNNING_OTHER_THREAD(gb)
     
     FILE *f = fopen(path, "rb");
+    size_t bin_size;
     if (!f) {
         GB_log(gb, "Could not open ROM: %s.\n", strerror(errno));
         return errno;
     }
     fseek(f, 0, SEEK_END);
-    gb->rom_size = rounded_rom_size(ftell(f));
+    bin_size = ftell(f);
+    gb->rom_size = rounded_rom_size(bin_size);
     fseek(f, 0, SEEK_SET);
     if (gb->rom) {
         free(gb->rom);
     }
     gb->rom = malloc(gb->rom_size);
     memset(gb->rom, 0xFF, gb->rom_size); /* Pad with 0xFFs */
-    fread(gb->rom, 1, gb->rom_size, f);
+    fread(gb->rom, 1, bin_size, f);
     fclose(f);
     init_new_rom(gb);
     return 0;
@@ -391,7 +393,7 @@ int GB_load_rom_from_zip(GB_gameboy_t *gb, const char *path)
     }
     gb->rom = malloc(gb->rom_size);
     memset(gb->rom, 0xFF, gb->rom_size);
-    unzReadCurrentFile(z, gb->rom, gb->rom_size);
+    unzReadCurrentFile(z, gb->rom, file_info.uncompressed_size);
     unzCloseCurrentFile(z);
     unzClose(z);
     init_new_rom(gb);

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -901,6 +901,8 @@ void GB_set_user_data(GB_gameboy_t *gb, void *data);
 int GB_load_boot_rom(GB_gameboy_t *gb, const char *path);
 void GB_load_boot_rom_from_buffer(GB_gameboy_t *gb, const unsigned char *buffer, size_t size);
 int GB_load_rom(GB_gameboy_t *gb, const char *path);
+int GB_load_rom_from_bin(GB_gameboy_t *gb, const char *path);
+int GB_load_rom_from_zip(GB_gameboy_t *gb, const char *path);
 void GB_load_rom_from_buffer(GB_gameboy_t *gb, const uint8_t *buffer, size_t size);
 int GB_load_isx(GB_gameboy_t *gb, const char *path);
 int GB_load_gbs_from_buffer(GB_gameboy_t *gb, const uint8_t *buffer, size_t size, GB_gbs_info_t *info);

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ GL_LDFLAGS := $(shell $(PKG_CONFIG) --libs gl || echo -lGL)
 endif
 
 ifneq ($(ENABLE_MINIZIP),0)
-MINIZIP_CPPFLAGS := -DHAVE_MINIZIP
+MINIZIP_CPPFLAGS := -DGB_HAS_MINIZIP
 ifeq (,$(PKG_CONFIG))
 MINIZIP_LDFLAGS := -lminizip
 else

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ $(BIN)/SameBoy-iOS.app: $(BIN)/SameBoy-iOS.app/SameBoy \
 
 $(BIN)/SameBoy-iOS.app/SameBoy: $(CORE_OBJECTS) $(IOS_OBJECTS)
 	-@$(MKDIR) -p $(dir $@)
-	$(CC) $^ -o $@ $(LDFLAGS)
+	$(CC) $^ -o $@ $(LDFLAGS) $(MINIZIP_LDFLAGS)
 ifeq ($(CONF), release)
 	$(STRIP) $@
 endif
@@ -406,7 +406,7 @@ endif
 
 $(BIN)/SameBoy.app/Contents/MacOS/SameBoy: $(CORE_OBJECTS) $(COCOA_OBJECTS)
 	-@$(MKDIR) -p $(dir $@)
-	$(CC) $^ -o $@ $(LDFLAGS) $(FAT_FLAGS) -framework OpenGL -framework AudioToolbox -framework AudioUnit -framework AVFoundation -framework CoreVideo -framework CoreMedia -framework IOKit -framework PreferencePanes -framework Carbon -framework QuartzCore -framework Security -framework WebKit -weak_framework Metal -weak_framework MetalKit
+	$(CC) $^ -o $@ $(LDFLAGS) $(FAT_FLAGS) $(MINIZIP_LDFLAGS) -framework OpenGL -framework AudioToolbox -framework AudioUnit -framework AVFoundation -framework CoreVideo -framework CoreMedia -framework IOKit -framework PreferencePanes -framework Carbon -framework QuartzCore -framework Security -framework WebKit -weak_framework Metal -weak_framework MetalKit
 ifeq ($(CONF), release)
 	$(STRIP) $@
 endif
@@ -431,7 +431,7 @@ endif
 # once in the QL Generator. It should probably become a dylib instead.
 $(BIN)/SameBoy.qlgenerator/Contents/MacOS/SameBoyQL: $(CORE_OBJECTS) $(QUICKLOOK_OBJECTS)
 	-@$(MKDIR) -p $(dir $@)
-	$(CC) $^ -o $@ $(LDFLAGS) $(FAT_FLAGS) -Wl,-exported_symbols_list,QuickLook/exports.sym -bundle -framework Cocoa -framework Quicklook
+	$(CC) $^ -o $@ $(LDFLAGS) $(FAT_FLAGS) $(MINIZIP_LDFLAGS) -Wl,-exported_symbols_list,QuickLook/exports.sym -bundle -framework Cocoa -framework Quicklook
 ifeq ($(CONF), release)
 	$(STRIP) $@
 endif
@@ -484,7 +484,7 @@ $(BIN)/SDL/SDL2.dll:
 
 $(BIN)/tester/sameboy_tester: $(CORE_OBJECTS) $(TESTER_OBJECTS)
 	-@$(MKDIR) -p $(dir $@)
-	$(CC) $^ -o $@ $(LDFLAGS)
+	$(CC) $^ -o $@ $(LDFLAGS) $(MINIZIP_LDFLAGS)
 ifeq ($(CONF), release)
 	$(STRIP) $@
 	$(CODESIGN) $@
@@ -492,7 +492,7 @@ endif
 
 $(BIN)/tester/sameboy_tester.exe: $(CORE_OBJECTS) $(SDL_OBJECTS)
 	-@$(MKDIR) -p $(dir $@)
-	$(CC) $^ -o $@ $(LDFLAGS) -Wl,/subsystem:console
+	$(CC) $^ -o $@ $(LDFLAGS) $(MINIZIP_LDFLAGS) -Wl,/subsystem:console
 
 $(BIN)/SDL/%.bin: $(BOOTROMS_DIR)/%.bin
 	-@$(MKDIR) -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ endif
 ifneq ($(ENABLE_MINIZIP),0)
 MINIZIP_CPPFLAGS := -DGB_HAS_MINIZIP
 ifeq (,$(PKG_CONFIG))
-MINIZIP_LDFLAGS := -lminizip
+MINIZIP_LDFLAGS := -lminizip -lz
 else
 MINIZIP_LDFLAGS := $(shell $(PKG_CONFIG) --libs minizip)
 endif

--- a/OpenDialog/gtk.c
+++ b/OpenDialog/gtk.c
@@ -109,6 +109,7 @@ char *do_open_rom_dialog(void)
     gtk_file_filter_add_pattern(filter, "*.gbc");
     gtk_file_filter_add_pattern(filter, "*.sgb");
     gtk_file_filter_add_pattern(filter, "*.isx");
+    gtk_file_filter_add_pattern(filter, "*.zip");
     gtk_file_filter_set_name(filter, "Game Boy ROMs");
     gtk_file_chooser_add_filter(dialog, filter);
     

--- a/OpenDialog/windows.c
+++ b/OpenDialog/windows.c
@@ -26,7 +26,7 @@ char *do_open_rom_dialog(void)
     dialog.lStructSize = sizeof(dialog);
     dialog.lpstrFile = filename;
     dialog.nMaxFile = MAX_PATH;
-    dialog.lpstrFilter = L"Game Boy ROMs\0*.gb;*.gbc;*.sgb;*.isx\0All files\0*.*\0\0";
+    dialog.lpstrFilter = L"Game Boy ROMs\0*.gb;*.gbc;*.sgb;*.isx;*.zip\0All files\0*.*\0\0";
     dialog.nFilterIndex = 1;
     dialog.lpstrFileTitle = NULL;
     dialog.nMaxFileTitle = 0;


### PR DESCRIPTION
Solves https://github.com/LIJI32/SameBoy/issues/399, and I think it's a useful feature I plan to use locally.

This adds a new dependency ([minizip](https://www.winimage.com/zLibDll/minizip.html)), some tests in the makefile, and a little bit of ifdef spaghetti. I added an `ENABLE_MINIZIP` variable to make this feature optional, but I defaulted it to 1.

I tried to be careful in editing the makefile, but I haven't tested on Windows or OS X. Minizip is very small (just a single .c/.h pair), so the best solution might be to just copy-paste the entire thing into the project and enable the feature unconditionally, which would get rid of the makefile checks and the ifdef spaghetti.

It does feel like this change belongs outside of `Core/gb.c`, for example in `SDL/main.c` where `GB_load_rom` is called. However, code would have to be changed at every call site of `GB_load_rom`, and there are a handful of those. Instead, this just makes `GB_load_rom` "do the right thing" transparently, and adds a `GB_load_rom_from_bin` in case anybody ever needs to access the old behavior. I am open to refactoring this patch to work some other way, though.