### PR TITLE
Changed Makefile to work on recent MacOS without XCode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,12 +191,22 @@ REREGISTER_LDFLAGS := $(LDFLAGS) -lobjc -framework CoreServices -framework Found
 LDFLAGS += -lobjc -framework UIKit -framework Foundation -framework CoreGraphics -framework Metal -framework MetalKit -framework AudioToolbox -framework AVFoundation -framework QuartzCore -framework CoreMotion -framework CoreVideo -framework CoreMedia -framework CoreImage -weak_framework CoreHaptics 
 CODESIGN := codesign -fs -
 else
+
+# Try to detect MacOS SDK
 ifeq ($(PLATFORM),Darwin)
 SYSROOT := $(shell xcodebuild -sdk macosx -version Path 2> $(NULL))
+
+# User doesn't have XCode
 ifeq ($(SYSROOT),)
-SYSROOT := /Library/Developer/CommandLineTools/SDKs/$(shell ls /Library/Developer/CommandLineTools/SDKs/ | grep 10 | tail -n 1)
+SYSROOT := $(shell xcrun --show-sdk-path) 
 endif
-ifeq ($(SYSROOT),/Library/Developer/CommandLineTools/SDKs/)
+
+# Let's see if we found command-line tools
+# findstring (https://www.gnu.org/software/make/manual/html_node/Text-Functions.html#index-findstring)
+# can be used to construct a "substring" like function for Make
+# So the comparison here is if findstring returns "" upon comparing
+# /Library/Developer/CommandLineTools/SDKs and $(SYSROOT), SYSROOT does not contain
+ifeq (,$(findstring /Library/Developer/CommandLineTools/SDKs,$(SYSROOT)))
 $(error Could not find a macOS SDK)
 endif
 


### PR DESCRIPTION
Currently, the Makefile fails if:

1) The user doesn't have XCode
2) The installed OS is a recent version of MacOS with a version higher than `10`

I've changed the `Makefile` to use `xcrun --show-sdk-path` instead. This has the added advantage of, if the tools aren't there, popping up a prompt on the OS for the user to install them (unlikely, if they already have `git` and `make`, but still possible).

Tested both the happy path of "SameBoy" still builds, as well as the error path `xcrun --show-sdk-path` returning a multiline error message, rather than the expected path. Make's string functions can be funky, but I've added an explanatory comment.

Your CONTRIBUTING file didn't say much about contributing to `Makefile`, so LMK if I can/need to change anything.