### PR TITLE
Changed CFLAG from -O3 to -O2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ endif
 ifeq ($(CONF),debug)
 CFLAGS += -g
 else ifeq ($(CONF), release)
-CFLAGS += -O3 -DNDEBUG
+CFLAGS += -O2 -DNDEBUG
 STRIP := strip
 CODESIGN := true
 ifeq ($(PLATFORM),Darwin)


### PR DESCRIPTION
According to the Gentoo Wiki, using -O3 is unlikely to cause any performance boost and can actually degrade performance. From testing the code, it seems that using -O3 causes a longer installation time and increased the 
build size by ~100 MB.