### PR TITLE
Library access to raw APU channel volumes

### DIFF
--- a/Core/apu.c
+++ b/Core/apu.c
@@ -1761,6 +1761,7 @@ bool GB_is_channel_muted(GB_gameboy_t *gb, GB_channel_t channel)
     return gb->apu_output.channel_muted[channel];
 }
 
+// Note: this intentionally does not check to see if the channel is muted.
 uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel) {
     switch (channel) {
         case GB_SQUARE_1:
@@ -1778,11 +1779,13 @@ uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel) {
     }
 }
 
-uint8_t GB_get_channel_amplitude(GB_gameboy_t *gb, GB_channel_t channel) {
+uint8_t GB_get_channel_amplitude(GB_gameboy_t *gb, GB_channel_t channel)
+{
     return gb->apu.is_active[channel] ? gb->apu.samples[channel] : 0;
 }
 
-uint16_t GB_get_channel_period(GB_gameboy_t *gb, GB_channel_t channel) {
+uint16_t GB_get_channel_period(GB_gameboy_t *gb, GB_channel_t channel)
+{
     switch (channel) {
         case GB_SQUARE_1:
         case GB_SQUARE_2:
@@ -1800,14 +1803,16 @@ uint16_t GB_get_channel_period(GB_gameboy_t *gb, GB_channel_t channel) {
 }
 
 // wave_table is a user allocated uint8_t[32] array
-void GB_get_apu_wave_table(GB_gameboy_t *gb, uint8_t *wave_table) {
+void GB_get_apu_wave_table(GB_gameboy_t *gb, uint8_t *wave_table)
+{
     for (unsigned i = GB_IO_WAV_START; i <= GB_IO_WAV_END; i++) {
         wave_table[2 * (i - GB_IO_WAV_START)] = gb->io_registers[i] >> 4;
         wave_table[2 * (i - GB_IO_WAV_START) + 1] = gb->io_registers[i] & 0xF;
     }
 }
 
-bool GB_get_channel_edge_triggered(GB_gameboy_t *gb, GB_channel_t channel) {
+bool GB_get_channel_edge_triggered(GB_gameboy_t *gb, GB_channel_t channel)
+{
     bool edge_triggered = gb->apu_output.edge_triggered[channel];
     gb->apu_output.edge_triggered[channel] = false;
     return edge_triggered;

--- a/Core/apu.c
+++ b/Core/apu.c
@@ -731,7 +731,7 @@ void GB_apu_run(GB_gameboy_t *gb, bool force)
                     uint8_t duty = gb->io_registers[i == GB_SQUARE_1? GB_IO_NR11 :GB_IO_NR21] >> 6;
                     uint8_t edge_sample_index = (const uint8_t[]){7, 7, 5, 1}[duty];
                     if (gb->apu.square_channels[i].current_sample_index == edge_sample_index) {
-                        gb->apu.square_channels[i].edge_triggered = true;
+                        gb->apu_output.edge_triggered[i] = true;
                     }
                 }
                 if (cycles_left) {
@@ -753,7 +753,7 @@ void GB_apu_run(GB_gameboy_t *gb, bool force)
                 update_wave_sample(gb, cycles - cycles_left);
                 gb->apu.wave_channel.wave_form_just_read = true;
                 if (gb->apu.wave_channel.current_sample_index == 0) {
-                    gb->apu.wave_channel.edge_triggered = true;
+                    gb->apu_output.edge_triggered[GB_WAVE] = true;
                 }
             }
             if (cycles_left) {
@@ -814,7 +814,7 @@ void GB_apu_run(GB_gameboy_t *gb, bool force)
             }
             else {
                 gb->apu.noise_channel.countdown_reloaded = true;
-                gb->apu.noise_channel.edge_triggered = true;
+                gb->apu_output.edge_triggered[GB_NOISE] = true;
             }
         }
     }
@@ -1808,26 +1808,7 @@ void GB_get_apu_wave_table(GB_gameboy_t *gb, uint8_t *wave_table) {
 }
 
 bool GB_get_channel_edge_triggered(GB_gameboy_t *gb, GB_channel_t channel) {
-    bool edge_triggered;
-    switch (channel) {
-        case GB_SQUARE_1:
-        case GB_SQUARE_2:
-            edge_triggered = gb->apu.square_channels[channel].edge_triggered;
-            gb->apu.square_channels[channel].edge_triggered = false;
-            break;
-
-        case GB_WAVE:
-            edge_triggered = gb->apu.wave_channel.edge_triggered;
-            gb->apu.wave_channel.edge_triggered = false;
-            break;
-
-        case GB_NOISE:
-            edge_triggered = gb->apu.noise_channel.edge_triggered;
-            gb->apu.noise_channel.edge_triggered = false;
-            break;
-
-        default:
-            return false;
-    }
+    bool edge_triggered = gb->apu_output.edge_triggered[channel];
+    gb->apu_output.edge_triggered[channel] = false;
     return edge_triggered;
 }

--- a/Core/apu.c
+++ b/Core/apu.c
@@ -726,8 +726,10 @@ void GB_apu_run(GB_gameboy_t *gb, bool force)
                         gb->apu.pcm_mask[0] &= i == GB_SQUARE_1? 0xF0 : 0x0F;
                     }
                     gb->apu.square_channels[i].did_tick = true;
-                    gb->apu.square_channels[i].edge_triggered = true;
                     update_square_sample(gb, i);
+                    if (gb->apu.square_channels[i].current_sample_index == 0) {
+                        gb->apu.square_channels[i].edge_triggered = true;
+                    }
                 }
                 if (cycles_left) {
                     gb->apu.square_channels[i].sample_countdown -= cycles_left;
@@ -747,7 +749,9 @@ void GB_apu_run(GB_gameboy_t *gb, bool force)
                     gb->io_registers[GB_IO_WAV_START + (gb->apu.wave_channel.current_sample_index >> 1)];
                 update_wave_sample(gb, cycles - cycles_left);
                 gb->apu.wave_channel.wave_form_just_read = true;
-                gb->apu.wave_channel.edge_triggered = true;
+                if (gb->apu.wave_channel.current_sample_index == 0) {
+                    gb->apu.wave_channel.edge_triggered = true;
+                }
             }
             if (cycles_left) {
                 gb->apu.wave_channel.sample_countdown -= cycles_left;

--- a/Core/apu.c
+++ b/Core/apu.c
@@ -1768,7 +1768,7 @@ uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel) {
             return gb->apu.square_channels[channel].current_volume;
 
         case GB_WAVE:
-            return (const uint8_t[]){0, 4, 8, 0, 0xF}[gb->apu.wave_channel.shift];
+            return (const uint8_t[]){0xF, 8, 4, 0, 0}[gb->apu.wave_channel.shift];
 
         case GB_NOISE:
             return gb->apu.noise_channel.current_volume;

--- a/Core/apu.c
+++ b/Core/apu.c
@@ -1762,7 +1762,8 @@ bool GB_is_channel_muted(GB_gameboy_t *gb, GB_channel_t channel)
 }
 
 // Note: this intentionally does not check to see if the channel is muted.
-uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel) {
+uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel)
+{
     switch (channel) {
         case GB_SQUARE_1:
         case GB_SQUARE_2:

--- a/Core/apu.c
+++ b/Core/apu.c
@@ -727,7 +727,10 @@ void GB_apu_run(GB_gameboy_t *gb, bool force)
                     }
                     gb->apu.square_channels[i].did_tick = true;
                     update_square_sample(gb, i);
-                    if (gb->apu.square_channels[i].current_sample_index == 0) {
+
+                    uint8_t duty = gb->io_registers[i == GB_SQUARE_1? GB_IO_NR11 :GB_IO_NR21] >> 6;
+                    uint8_t edge_sample_index = (const uint8_t[]){7, 7, 5, 1}[duty];
+                    if (gb->apu.square_channels[i].current_sample_index == edge_sample_index) {
                         gb->apu.square_channels[i].edge_triggered = true;
                     }
                 }

--- a/Core/apu.c
+++ b/Core/apu.c
@@ -1750,3 +1750,49 @@ bool GB_is_channel_muted(GB_gameboy_t *gb, GB_channel_t channel)
 {
     return gb->apu_output.channel_muted[channel];
 }
+
+uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel) {
+    switch (channel) {
+        case GB_SQUARE_1:
+        case GB_SQUARE_2:
+            return gb->apu.square_channels[channel].current_volume;
+
+        case GB_WAVE:
+            return (const uint8_t[]){0, 4, 8, 0, 0xF}[gb->apu.wave_channel.shift];
+
+        case GB_NOISE:
+            return gb->apu.noise_channel.current_volume;
+
+        default:
+            return 0;
+    }
+}
+
+uint8_t GB_get_channel_amplitude(GB_gameboy_t *gb, GB_channel_t channel) {
+    return gb->apu.is_active[channel] ? gb->apu.samples[channel] : 0;
+}
+
+uint16_t GB_get_channel_period(GB_gameboy_t *gb, GB_channel_t channel) {
+    switch (channel) {
+        case GB_SQUARE_1:
+        case GB_SQUARE_2:
+            return gb->apu.square_channels[channel].sample_length;
+
+        case GB_WAVE:
+            return gb->apu.wave_channel.sample_length;
+
+        case GB_NOISE:
+            return (gb->io_registers[GB_IO_NR43] & 7) << (gb->io_registers[GB_IO_NR43] >> 4);
+
+        default:
+            return 0;
+    }
+}
+
+// wave_table is a user allocated uint8_t[32] array
+void GB_get_apu_wave_table(GB_gameboy_t *gb, uint8_t *wave_table) {
+    for (unsigned i = GB_IO_WAV_START; i <= GB_IO_WAV_END; i++) {
+        wave_table[2 * (i - GB_IO_WAV_START)] = gb->io_registers[i] >> 4;
+        wave_table[2 * (i - GB_IO_WAV_START) + 1] = gb->io_registers[i] & 0xF;
+    }
+}

--- a/Core/apu.h
+++ b/Core/apu.h
@@ -188,6 +188,10 @@ void GB_set_interference_volume(GB_gameboy_t *gb, double volume);
 void GB_apu_set_sample_callback(GB_gameboy_t *gb, GB_sample_callback_t callback);
 int GB_start_audio_recording(GB_gameboy_t *gb, const char *path, GB_audio_format_t format);
 int GB_stop_audio_recording(GB_gameboy_t *gb);
+uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel);
+uint8_t GB_get_channel_amplitude(GB_gameboy_t *gb, GB_channel_t channel);
+uint16_t GB_get_channel_period(GB_gameboy_t *gb, GB_channel_t channel);
+void GB_get_apu_wave_table(GB_gameboy_t *gb, uint8_t *wave_table);
 #ifdef GB_INTERNAL
 internal bool GB_apu_is_DAC_enabled(GB_gameboy_t *gb, GB_channel_t index);
 internal void GB_apu_write(GB_gameboy_t *gb, uint8_t reg, uint8_t value);

--- a/Core/apu.h
+++ b/Core/apu.h
@@ -92,8 +92,6 @@ typedef struct
         GB_envelope_clock_t envelope_clock;
         uint8_t delay; // Hack for CGB D/E phantom step due to how sample_countdown is implemented in SameBoy
         bool did_tick;
-
-        bool edge_triggered;
     } square_channels[2];
 
     struct {
@@ -109,8 +107,6 @@ typedef struct
         bool wave_form_just_read;
         bool pulsed;
         uint8_t bugged_read_countdown;
-
-        bool edge_triggered;
     } wave_channel;
 
     struct {
@@ -131,8 +127,6 @@ typedef struct
         bool countdown_reloaded;
         uint8_t dmg_delayed_start;
         GB_envelope_clock_t envelope_clock;
-
-        bool edge_triggered;
     } noise_channel;
 
     GB_ENUM(uint8_t, {
@@ -168,6 +162,7 @@ typedef struct {
     GB_sample_t summed_samples[GB_N_CHANNELS];
     double dac_discharge[GB_N_CHANNELS];
     bool channel_muted[GB_N_CHANNELS];
+    bool edge_triggered[GB_N_CHANNELS];
 
     GB_highpass_mode_t highpass_mode;
     double highpass_rate;

--- a/Core/apu.h
+++ b/Core/apu.h
@@ -92,6 +92,8 @@ typedef struct
         GB_envelope_clock_t envelope_clock;
         uint8_t delay; // Hack for CGB D/E phantom step due to how sample_countdown is implemented in SameBoy
         bool did_tick;
+
+        bool edge_triggered;
     } square_channels[2];
 
     struct {
@@ -107,6 +109,8 @@ typedef struct
         bool wave_form_just_read;
         bool pulsed;
         uint8_t bugged_read_countdown;
+
+        bool edge_triggered;
     } wave_channel;
 
     struct {
@@ -127,6 +131,8 @@ typedef struct
         bool countdown_reloaded;
         uint8_t dmg_delayed_start;
         GB_envelope_clock_t envelope_clock;
+
+        bool edge_triggered;
     } noise_channel;
 
     GB_ENUM(uint8_t, {
@@ -192,6 +198,7 @@ uint8_t GB_get_channel_volume(GB_gameboy_t *gb, GB_channel_t channel);
 uint8_t GB_get_channel_amplitude(GB_gameboy_t *gb, GB_channel_t channel);
 uint16_t GB_get_channel_period(GB_gameboy_t *gb, GB_channel_t channel);
 void GB_get_apu_wave_table(GB_gameboy_t *gb, uint8_t *wave_table);
+bool GB_get_channel_edge_triggered(GB_gameboy_t *gb, GB_channel_t channel);
 #ifdef GB_INTERNAL
 internal bool GB_apu_is_DAC_enabled(GB_gameboy_t *gb, GB_channel_t index);
 internal void GB_apu_write(GB_gameboy_t *gb, uint8_t reg, uint8_t value);


### PR DESCRIPTION
API implementation for the non-redundant methods laid out in #548.

This includes methods for fetching channel volume, pre-mix amplitude, and period, alongside the wave table with entry splitting as well as edge trigger detection. These are useful for visualizing APU data, e.g. for oscilloscope views of individual channels.