### PR TITLE
Removed unused local variable "lineIndex" that was generating a warning.

### DIFF
--- a/HexFiend/HFRepresenterTextView.m
+++ b/HexFiend/HFRepresenterTextView.m
@@ -1206,7 +1206,6 @@ static size_t unionAndCleanLists(NSRect *rectList, id *valueList, size_t count) 
     /* Start us off with the horizontal inset and move the baseline down by the ascender so our glyphs just graze the top of our view */
     textTransform.tx += [self horizontalContainerInset];
     textTransform.ty += [fontObject ascender] - lineHeight * [self verticalOffset];
-    NSUInteger lineIndex = 0;
     const NSUInteger maxGlyphCount = [self maximumGlyphCountForByteCount:bytesPerLine];
     NEW_ARRAY(struct HFGlyph_t, glyphs, maxGlyphCount);
     NEW_ARRAY(CGSize, advances, maxGlyphCount);
@@ -1269,7 +1268,6 @@ static size_t unionAndCleanLists(NSRect *rectList, id *valueList, size_t count) 
         else if (NSMinY(lineRectInBoundsSpace) > NSMaxY(clip)) {
             break;
         }
-        lineIndex++;
     }
     FREE_ARRAY(glyphs);
     FREE_ARRAY(advances);


### PR DESCRIPTION
This unused variable was generating a warning that was treated as an error and stopping the compilation on Mac.

```
HexFiend/HFRepresenterTextView.m:1209:16: error: unused variable 'lineIndex' [-Werror,-Wunused-variable]
    NSUInteger lineIndex = 0;
```

Compilation environment:

Apple M2
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin