### PR TITLE
Fix GB_ENUM on C++

### DIFF
--- a/Core/save_state.h
+++ b/Core/save_state.h
@@ -25,7 +25,7 @@
 #endif
 #endif
 
-#if __clang_major__ >= 8 || __GNUC__ >= 13
+#if __clang_major__ >= 8 || __GNUC__ >= 13 || defined(__cplusplus)
 #define GB_ENUM(type, ...) enum : type __VA_ARGS__
 #else
 #define GB_ENUM(type, ...) __typeof__((type)((enum __VA_ARGS__)0))


### PR DESCRIPTION
The else branch results in an error from defining a type in a cast (and is thus invalid for C++). The top branch should work, however.