### PR TITLE
Fix memory corruption on removal / update of cheats with the same address hash

### DIFF
--- a/Core/cheats.c
+++ b/Core/cheats.c
@@ -132,7 +132,7 @@ void GB_remove_cheat(GB_gameboy_t *gb, const GB_cheat_t *cheat)
                 *hash = NULL;
             }
             else {
-                *hash = malloc(sizeof(GB_cheat_hash_t) + sizeof(cheat) * (*hash)->size);
+                *hash = realloc(*hash, sizeof(GB_cheat_hash_t) + sizeof(cheat) * (*hash)->size);
             }
             break;
         }
@@ -228,7 +228,7 @@ void GB_update_cheat(GB_gameboy_t *gb, const GB_cheat_t *_cheat, const char *des
                     *hash = NULL;
                 }
                 else {
-                    *hash = malloc(sizeof(GB_cheat_hash_t) + sizeof(cheat) * (*hash)->size);
+                    *hash = realloc(*hash, sizeof(GB_cheat_hash_t) + sizeof(cheat) * (*hash)->size);
                 }
                 break;
             }


### PR DESCRIPTION
Previously instead of resizing the `GB_cheat_hash_t` to fit the new (smaller) number of cheats a new chunk of (uninitialized) memory was used.
Now we shrink the `GB_cheat_hash_t` by using `realloc` instead.

I have tested this change by:
1) Applying the following patch:
```diff
diff --git a/SDL/main.c b/SDL/main.c
index 5b2164d9..0d2710d9 100644
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -805,6 +805,15 @@ restart:
     }
     else {
         GB_load_rom(&gb, filename);
+
+        GB_add_cheat(&gb, "Cheat #0", 0x0000, 0x00, 0x12, 0x34, false, false);
+        GB_add_cheat(&gb, "Cheat #1", 0x3456, 0x12, 0x78, 0x90, true, true);
+        GB_add_cheat(&gb, "Cheat #2", 0x3456, 0x12, 0x78, 0x90, false, true);
+        GB_add_cheat(&gb, "Cheat #3", 0x3456, 0x12, 0x78, 0x90, true, false);
+        GB_add_cheat(&gb, "Cheat #4", 0x0995, 0xFF, 0xab, 0x42, false, true);
+        GB_add_cheat(&gb, "Cheat #5", 0xcdef, 0xab, 0x00, 0x00, false, true);
+        GB_add_cheat(&gb, "Cheat #6", 0x0000, 0x00, 0x00, 0x00, false, false);
+        GB_add_cheat(&gb, "Cheat #7", 0xffff, 0xff, 0xff, 0xff, true, true);
     }
     
     /* Configure battery */
```
2) Loading a game
3) Toggling a cheat so the cheat database gets saved to the file system
4) Loading the same game again

Previously step 4 would have crashed:
```
[New Thread 0x7ffff6442700 (LWP 182590)]

SameBoy v0.15.8ffff57b2700 (LWP 182591)]
[New Thread 0x7fffeddaf700 (LWP 182646)]
[New Thread 0x7fffedd6e700 (LWP 182647)]
> 
Thread 1 "sameboy" received signal SIGSEGV, Segmentation fault.
0x0000555555567ad3 in GB_remove_cheat ()
(gdb) bt
#0  0x0000555555567ad3 in GB_remove_cheat ()
#1  0x0000555555568532 in GB_load_cheats ()
#2  0x00005555555ab394 in run ()
#3  0x00005555555aa66d in main ()
```