### PR TITLE
gb.h: add include guards for C++ projects

### DIFF
--- a/Core/gb.h
+++ b/Core/gb.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdalign.h>
@@ -1027,4 +1032,8 @@ internal void GB_clear_running_thread(GB_gameboy_t *gb);
 #define GB_clear_running_thread(gb)
 #endif
     
+#endif
+
+#ifdef __cplusplus
+}
 #endif


### PR DESCRIPTION
This is helpful for C++ projects like bsnes that wish to include gb.h without needing to set `extern "C"` themselves.