### PR TITLE
check if file exists before running

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -1041,7 +1041,7 @@ int main(int argc, char **argv)
         exit(1);
     }
     
-    if (argc == 2) {
+    if (argc == 2 && access(argv[1], F_OK) == 0) {
         filename = argv[1];
     }
 

--- a/SDL/main.c
+++ b/SDL/main.c
@@ -1041,8 +1041,13 @@ int main(int argc, char **argv)
         exit(1);
     }
     
-    if (argc == 2 && access(argv[1], F_OK) == 0) {
+    if (argc == 2) {
+      if (access(argv[1], F_OK) == 0) {
         filename = argv[1];
+      } else {
+        fprintf(stderr, "File not found: %s\n", argv[1]);
+        exit(1);
+      }
     }
 
     signal(SIGINT, debugger_interrupt);


### PR DESCRIPTION
I built SameBoy on WSL, passed a wrong argument on cli and it sort of broke windows even though it was running through WSL gui which was surprising. I had to restart to stop the screen from glitching, wasn't able to reproduce it though.

I added a basic check for if a file exists, otherwise there's no point trying to run and spam console right? This still lets you pass incorrect files but I guess we still want to be able to run roms with incorrect header checksum.

Edit: Just saw that Windows does have a message box but it doesn't stop it from running, that's why on Linux if you don't get the messagebox it looks like there is no error. I'll close this since it's better to update GB_load_boot_rom