### PR TITLE
apu: Do not dereference type-punned pointers

### DIFF
--- a/Core/apu.c
+++ b/Core/apu.c
@@ -100,7 +100,8 @@ static void update_sample(GB_gameboy_t *gb, GB_channel_t index, int8_t value, un
                 output.left = output.right = 0;
             }
             
-            if (*(uint32_t *)&(gb->apu_output.current_sample[index]) != *(uint32_t *)&output) {
+            if ((gb->apu_output.current_sample[index].left != output.left) ||
+                (gb->apu_output.current_sample[index].right != output.right)) {
                 refresh_channel(gb, index, cycles_offset);
                 gb->apu_output.current_sample[index] = output;
             }
@@ -131,7 +132,8 @@ static void update_sample(GB_gameboy_t *gb, GB_channel_t index, int8_t value, un
         if (likely(!gb->apu_output.channel_muted[index])) {
             output = (GB_sample_t){(0xF - value * 2) * left_volume, (0xF - value * 2) * right_volume};
         }
-        if (*(uint32_t *)&(gb->apu_output.current_sample[index]) != *(uint32_t *)&output) {
+        if ((gb->apu_output.current_sample[index].left != output.left) ||
+            (gb->apu_output.current_sample[index].right != output.right)) {
             refresh_channel(gb, index, cycles_offset);
             gb->apu_output.current_sample[index] = output;
         }

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ endif
 
 # These must come before the -Wno- flags
 WARNINGS += -Werror -Wall -Wno-unknown-warning -Wno-unknown-warning-option -Wno-missing-braces
-WARNINGS += -Wno-nonnull -Wno-unused-result -Wno-strict-aliasing -Wno-multichar -Wno-int-in-bool-context -Wno-format-truncation
+WARNINGS += -Wno-nonnull -Wno-unused-result -Wno-multichar -Wno-int-in-bool-context -Wno-format-truncation
 
 # Only add this flag if the compiler supports it
 ifeq ($(shell $(CC) -x c -c $(NULL) -o $(NULL) -Werror -Wpartial-availability 2> $(NULL); echo $$?),0)


### PR DESCRIPTION
Dereferencing type-punned pointers will break strict-aliasing rules.