### PR TITLE
Fix message always being logged when running ticks command

### DIFF
--- a/Core/debugger.c
+++ b/Core/debugger.c
@@ -1702,8 +1702,8 @@ static bool ticks(GB_gameboy_t *gb, char *arguments, char *modifiers, const debu
     GB_log(gb, "T-cycles: %llu\n", (unsigned long long)gb->debugger_ticks);
     GB_log(gb, "M-cycles: %llu\n", (unsigned long long)gb->debugger_ticks / 4);
     GB_log(gb, "Absolute 8MHz ticks: %llu\n", (unsigned long long)gb->absolute_debugger_ticks);
-    GB_log(gb, "Tick count reset.\n");
     if (!keep) {
+        GB_log(gb, "Tick count reset.\n");
         gb->debugger_ticks = 0;
         gb->absolute_debugger_ticks = 0;
     }


### PR DESCRIPTION
"Tick count reset." is currently logged even if the user supplied the 'keep' argument to the ticks command in the debugger.