### PR TITLE
Fix potential compiler warning on questionable code path

### DIFF
--- a/Core/gb.c
+++ b/Core/gb.c
@@ -1705,7 +1705,7 @@ static void GB_reset_internal(GB_gameboy_t *gb, bool quick)
     GB_update_clock_rate(gb);
     uint8_t rtc_section[GB_SECTION_SIZE(rtc)];
     memcpy(rtc_section, GB_GET_SECTION(gb, rtc), sizeof(rtc_section));
-    memset(gb, 0, (size_t)GB_GET_SECTION((GB_gameboy_t *) 0, unsaved));
+    memset(gb, 0, GB_SECTION_OFFSET(unsaved));
     memcpy(GB_GET_SECTION(gb, rtc), rtc_section, sizeof(rtc_section));
     gb->model = model;
     gb->version = GB_STRUCT_VERSION;


### PR DESCRIPTION
This line displayed a compiler warning to me: 
```
.../Core/gb.c:1708:27: warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Wgnu-null-pointer-arithmetic]
 1708 |     memset(gb, 0, (size_t)GB_GET_SECTION(NULL, unsaved));
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../Core/save_state.h:24:59: note: expanded from macro 'GB_GET_SECTION'
   24 | #define GB_GET_SECTION(gb, name) (void *)((uint8_t *)(gb) + GB_SECTION_OFFSET(name))
      |                                           ~~~~~~~~~~~~~~~ ^
```

The warning probably only surfaces with specific compiler/warning combinations used, but this line of code seems questionable anyways considering what it's actually trying to do, so I've simplified it and fixes the compiler warning at the same time.