### PR TITLE
call SDL_Quit() on exit to prevent a crash on app exit with linux/wayland

### DIFF
--- a/SDL/main.c
+++ b/SDL/main.c
@@ -1052,7 +1052,9 @@ int main(int argc, char **argv)
 #endif
 
     SDL_Init(SDL_INIT_EVERYTHING & ~SDL_INIT_AUDIO);
-    atexit(SDL_Quit);
+    // This is, essentially, best-effort.
+    // This function will not be called if the process is terminated in any way, anyhow.
+    (void)atexit(SDL_Quit);
 
     if ((console_supported = CON_start(completer))) {
         CON_set_repeat_empty(true);

--- a/SDL/main.c
+++ b/SDL/main.c
@@ -1054,7 +1054,7 @@ int main(int argc, char **argv)
     SDL_Init(SDL_INIT_EVERYTHING & ~SDL_INIT_AUDIO);
     // This is, essentially, best-effort.
     // This function will not be called if the process is terminated in any way, anyhow.
-    (void)atexit(SDL_Quit);
+    atexit(SDL_Quit);
 
     if ((console_supported = CON_start(completer))) {
         CON_set_repeat_empty(true);

--- a/SDL/main.c
+++ b/SDL/main.c
@@ -1052,6 +1052,8 @@ int main(int argc, char **argv)
 #endif
 
     SDL_Init(SDL_INIT_EVERYTHING & ~SDL_INIT_AUDIO);
+    atexit(SDL_Quit);
+
     if ((console_supported = CON_start(completer))) {
         CON_set_repeat_empty(true);
         CON_printf("SameBoy v" GB_VERSION "\n");


### PR DESCRIPTION
On Bluefin DX Linux (a Fedora Silverblue spinoff) closing the app window brings down the whole Gnome session. Ensuring that SDL_Quit() (https://wiki.libsdl.org/SDL2/SDL_Quit) is called on exit seems to prevent this. The problem happened with both Flatpak and self-compiled versions