### PR TITLE
Use `rgblink -x` instead of `dd`

### DIFF
--- a/BootROMs/cgb_boot.asm
+++ b/BootROMs/cgb_boot.asm
@@ -1238,6 +1238,7 @@ BootEnd:
 IF BootEnd > $900
     FAIL "BootROM overflowed: {BootEnd}"
 ENDC
+    ds $100 + $800 - @ ; Ensure that the ROM is padded up to standard size.
 
 SECTION "HRAM", HRAM[$FF80]
 TitleChecksum:

--- a/Makefile
+++ b/Makefile
@@ -638,9 +638,8 @@ $(BIN)/BootROMs/sgb2_boot: BootROMs/sgb_boot.asm
 $(BIN)/BootROMs/%.bin: BootROMs/%.asm $(OBJ)/BootROMs/SameBoyLogo.pb12
 	-@$(MKDIR) -p $(dir $@)
 	$(RGBASM) -i $(OBJ)/BootROMs/ -i BootROMs/ -o $@.tmp $<
-	$(RGBLINK) -o $@.tmp2 $@.tmp
-	dd if=$@.tmp2 of=$@ count=1 bs=$(if $(findstring cgb,$@)$(findstring agb,$@),2304,256) 2> $(NULL)
-	@rm $@.tmp $@.tmp2
+	$(RGBLINK) -x -o $@ $@.tmp
+	@rm $@.tmp
 
 # Libretro Core (uses its own build system)
 libretro:


### PR DESCRIPTION
This saves a few build steps and intermediate files.