### PR TITLE
Fix a memory leak in GBLoadROMTableViewController.m

### DIFF
--- a/iOS/GBLoadROMTableViewController.m
+++ b/iOS/GBLoadROMTableViewController.m
@@ -101,9 +101,9 @@
                 NSString *zipUTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)@"zip", NULL);
 
                 NSMutableSet *extensions = [NSMutableSet set];
-                [extensions addObjectsFromArray:(__bridge NSArray *)UTTypeCopyAllTagsWithClass((__bridge CFStringRef)gbUTI, kUTTagClassFilenameExtension)];
-                [extensions addObjectsFromArray:(__bridge NSArray *)UTTypeCopyAllTagsWithClass((__bridge CFStringRef)gbcUTI, kUTTagClassFilenameExtension)];
-                [extensions addObjectsFromArray:(__bridge NSArray *)UTTypeCopyAllTagsWithClass((__bridge CFStringRef)isxUTI, kUTTagClassFilenameExtension)];
+                [extensions addObjectsFromArray:(__bridge_transfer NSArray *)UTTypeCopyAllTagsWithClass((__bridge CFStringRef)gbUTI, kUTTagClassFilenameExtension)];
+                [extensions addObjectsFromArray:(__bridge_transfer NSArray *)UTTypeCopyAllTagsWithClass((__bridge CFStringRef)gbcUTI, kUTTagClassFilenameExtension)];
+                [extensions addObjectsFromArray:(__bridge_transfer NSArray *)UTTypeCopyAllTagsWithClass((__bridge CFStringRef)isxUTI, kUTTagClassFilenameExtension)];
                 
                 if (extensions.count != 3) {
                     if (![[NSUserDefaults standardUserDefaults] boolForKey:@"GBShownUTIWarning"]) {


### PR DESCRIPTION
Fix a memory leak with calls to `UTTypeCopyAllTagsWithClass`.

`UTTypeCopyAllTagsWithClass` follows the "Create rule", which means that we are responsible with releasing the data when done. As the value returned goes out-of-scope after `-[NSSet addObjectsFromArray:]` gets done, the pointer is left unreleased.