### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/Cocoa/GBTerminalTextFieldCell.m
+++ b/Cocoa/GBTerminalTextFieldCell.m
@@ -45,7 +45,7 @@
 {
     self = [super init];
     if (!self) {
-        return NULL;
+        return nil;
     }
     lines = [[NSMutableOrderedSet alloc] init];
     return self;

--- a/HexFiend/HFPasteboardOwner.m
+++ b/HexFiend/HFPasteboardOwner.m
@@ -44,7 +44,7 @@ NSString *const HFPrivateByteArrayPboardType = @"HFPrivateByteArrayPboardType";
         [[NSNotificationCenter defaultCenter] removeObserver:self name:HFPrepareForChangeInFileNotification object:nil];
     }
     if (retainedSelfOnBehalfOfPboard) {
-        CFRelease(self);
+        [self release];
         retainedSelfOnBehalfOfPboard = NO;
     }
 }

--- a/iOS/GBViewController.m
+++ b/iOS/GBViewController.m
@@ -612,7 +612,7 @@ static void rumbleCallback(GB_gameboy_t *gb, double amp)
     const char *_teamIdentifier = xpc_dictionary_get_string(entitlements, "com.apple.developer.team-identifier");
     NSString *teamIdentifier = _teamIdentifier? @(_teamIdentifier) : nil;
     
-    CFRelease(entitlements);
+    xpc_release(entitlements);
     
     if (!entIdentifier) { // No identifier. Installed using a jailbreak, we're fine.
         return;


### PR DESCRIPTION
- Use nil, not NULL for objects
- Call Objective-C release instead of CFRelease (unless like we are hacking around ARC, which we are not)
- xpc_release to release xpc objects.