### PR TITLE
build: lib target now builds a shared library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,17 @@ On Windows, SameBoy also requires:
 To compile, simply run `make`. The targets are:
  * `cocoa` (Default for macOS)
  * `sdl` (Default for everything else)
- * `lib` (Creates libsameboy.o and libsameboy.a for statically linking SameBoy, as well as a headers directory with corresponding headers; currently not supported on Windows due to linker limitations)
+ * `lib` (Creates libsameboy.o, libsameboy.a and libsameboy.so for linking SameBoy, as well as a headers directory with corresponding headers; currently not supported on Windows due to linker limitations)
  * `ios` (Plain iOS .app bundle), `ios-ipa` (iOS IPA archive for side-loading), `ios-deb` (iOS deb package for jailbroken devices)
  * `libretro`
  * `bootroms`
  * `tester` 
+
+For convenience, when installing the static and shared libraries is
+desired, you can specify the LIBRARY=1 make variable to have the
+libraries built as part of the default target, as well as installed,
+along the headers. Alternatively, `LIBRARY=shared` will install just
+the shared library, while `LIBRARY=static` only the static one.
 
 You may also specify `CONF=debug` (default), `CONF=release`, `CONF=native_release` or `CONF=fat_release`  to control optimization, symbols and multi-architectures. `native_release` is faster than `release`, but is optimized to the host's CPU and therefore is not portable. `fat_release` is exclusive to macOS and builds x86-64 and ARM64 fat binaries; this requires using a recent enough `clang` and macOS SDK using `xcode-select`, or setting them explicitly with `CC=` and `SYSROOT=`, respectively. All other configurations will build to your host architecture, except for the iOS targets. You may set `BOOTROMS_DIR=...` to a directory containing precompiled boot ROM files, otherwise the build system will compile and use SameBoy's own boot ROMs.
 

--- a/sameboy.pc.in
+++ b/sameboy.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: sameboy
+Description: The SameBoy library
+Version: @version@
+Cflags: -I${includedir}/sameboy
+Libs: -L${libdir} -lsameboy


### PR DESCRIPTION
A new 'LIBRARY' variable also causes the libraries to be installed along the headers and a newly introduced pkg-config file.

* Makefile (DEFAULT) [LIBRARY]: Add lib to it. (CFLAGS): Add -fPIC.
(PKGCONF_DIR, LIBS, PKGCONF_FILE): New variables.
(lib): Express target via LIBS; add $(PKGCONF_FILE). (install) [LIBRARY]: Conditionally add lib and pkgconf targets, as well as associated recipes.
($(LIBDIR)/libsameboy.so, PKGCONF_FILE, pkgconf): New targets. (.PHONY): Register pkgconf.
* README.md: Update doc.
* sameboy.pc.in: New file.