### PR TITLE
Fix macOS camera aspect ratio

### DIFF
--- a/Cocoa/Document.m
+++ b/Cocoa/Document.m
@@ -2067,7 +2067,7 @@ enum GBWindowResizeAction
                 NSError *error;
                 AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType: AVMediaTypeVideo];
                 AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice: device error: &error];
-                CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions([[[device formats] lastObject] formatDescription]);
+                CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions([[device activeFormat] formatDescription]);
 
                 if (!input) {
                     GB_camera_updated(&_gb);


### PR DESCRIPTION
Camera emulation on macOS without this change results in a horizontally squished image for me; with this change, I get a normal-looking image.

The bug (at least on my machine) was that `[device formats]` returns several resolutions, not all of them matching the current one; in my case, the last one (which the buggy code used to pick via `lastObject`) had an 1:1 aspect ratio, whereas the native aspect ratio is actually 16:9. Picking the active one fixes that.

I've only tried this on this one machine.