### PR TITLE
correct mimetype location to follow the shared mime info specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -783,7 +783,7 @@ install: $(BIN)/XdgThumbnailer/sameboy-thumbnailer sdl $(shell find FreeDesktop)
 	install -d $(DESTDIR)$(DATA_DIR)/BootROMs
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)$(PREFIX)/share/thumbnailers
-	install -d $(DESTDIR)$(PREFIX)/share/mime
+	install -d $(DESTDIR)$(PREFIX)/share/mime/packages
 	install -d $(DESTDIR)$(PREFIX)/share/applications
 	
 	(cd $(BIN)/SDL && find . \! -name sameboy -type f -exec install -m 644 {} "$(abspath $(DESTDIR))$(DATA_DIR)/{}" \; )
@@ -799,7 +799,7 @@ ifeq ($(DESTDIR),)
 		xdg-icon-resource install --novendor --theme hicolor --size $$size --context mimetypes FreeDesktop/ColorCartridge/$${size}x$${size}.png x-gameboy-color-rom; \
 	done
 else
-	install -m 644 FreeDesktop/sameboy.xml $(DESTDIR)$(PREFIX)/share/mime/sameboy.xml
+	install -m 644 FreeDesktop/sameboy.xml $(DESTDIR)$(PREFIX)/share/mime/packages/sameboy.xml
 	install -m 644 FreeDesktop/sameboy.desktop $(DESTDIR)$(PREFIX)/share/applications/sameboy.desktop
 	for size in 16x16 32x32 64x64 128x128 256x256 512x512; do \
 		install -d $(DESTDIR)$(PREFIX)/share/icons/hicolor/$$size/apps; \


### PR DESCRIPTION
according to the shared-mime-info specification it should be installed into the packages folder:

> Each application that wishes to contribute to the MIME database will install a single XML file, named after the application, into one of the three <MIME>/packages/ directories (depending on where the user requested the application be installed). After installing, uninstalling or modifying this file, the application MUST run the update-mime-database command, which is provided by the freedesktop.org shared database[[SharedMIME](https://specifications.freedesktop.org/shared-mime-info-spec/latest/bi01.html#id-1.5.6)].

[Unified system | Shared MIME-info Database](https://specifications.freedesktop.org/shared-mime-info-spec/latest/ar01s02.html#s2_layout)

I saw that this change was made for FreeBSD but they seem to support the shared mime database
![image](https://github.com/user-attachments/assets/9dbdfd8b-e6a9-4911-a4c9-5a2c55411796)

