### PR TITLE
add missing include for toupper and isxdigit

### DIFF
--- a/SDL/gui.c
+++ b/SDL/gui.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
+#include <ctype.h>
 #include "utils.h"
 #include "gui.h"
 #include "font.h"


### PR DESCRIPTION
when building with GCC 12 on Fedora 42 it fails due to `toupper` and `isxidigit` not being defined.

