### PR TITLE
SPM support for Core

### DIFF
--- a/Core/apu.h
+++ b/Core/apu.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include "defs.h"
+#include "save_state.h"
 
 #define GB_BAND_LIMITED_WIDTH 16
 #define GB_BAND_LIMITED_PHASES 512

--- a/Core/display.h
+++ b/Core/display.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "gb.h"
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/Core/save_state.h
+++ b/Core/save_state.h
@@ -2,6 +2,7 @@
 
 /* Macros to make the GB_gameboy_t struct more future compatible when state saving */
 #include <stddef.h>
+#include "model.h"
 
 #define GB_PADDING(type, old_usage) type old_usage##__do_not_use
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SameBoy",
+    products: [
+        .library(name: "SameBoyCore", targets: ["SameBoyCore"]),
+    ],
+    targets: [
+        .target(
+            name: "SameBoyCore",
+            path: "Core",
+            publicHeadersPath: ".",
+            cSettings: [
+                .define("GB_INTERNAL"),
+                .define("GB_VERSION", to: "\"1.0.1\"")
+            ]
+        ),
+        .testTarget(
+            name: "SameBoyCoreTests",
+            dependencies: ["SameBoyCore"],
+            path: "SameBoyCoreTests"
+        )
+    ]
+)

--- a/SameBoyCoreTests/SameboyPackageTests.swift
+++ b/SameBoyCoreTests/SameboyPackageTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SameBoyCore
+
+final class SameBoyCoreTests: XCTestCase {
+    func test_GB_init() throws {
+        // check if it compiles and does not crash
+        
+        var gb = GB_gameboy_t()
+        GB_init(&gb, GB_MODEL_MGB)
+        GB_free(&gb)
+    }
+}


### PR DESCRIPTION
Added basic support for Swift Package Manager. SPM can handle C libraries, and Swift supports binding to them, which means someone else can implement a wrapper on top of it. 

I had to make some adjustments in headers:
- Unnecessary circular dependency of `display.h` on `gb.h`
- `apu.h` using `GB_ENUM` without including `save_state.h`
- `save_state.h` using `GB_gameboy_t` without including `model.h`