### PR TITLE
fix typeof usage in gb.h

### DIFF
--- a/Core/gb.h
+++ b/Core/gb.h
@@ -235,7 +235,7 @@ enum {
     GB_IO_PCM34      = 0x77, // Channels 3 and 4 amplitudes
 };
 
-static const typeof(GB_IO_PGB) __attribute__((deprecated("Use GB_IO_PGB instead"))) GB_IO_UNKNOWN5 = GB_IO_PGB;
+static const __typeof__(GB_IO_PGB) __attribute__((deprecated("Use GB_IO_PGB instead"))) GB_IO_UNKNOWN5 = GB_IO_PGB;
 
 typedef enum {
     GB_LOG_BOLD = 1,


### PR DESCRIPTION
`typeof` is not part of the C standard until C23, so `__typeof__` should be used instead. `defs.h` has a `#define typeof __typeof__` line, but it's guarded behind `GB_INTERNAL` which may not be defined when #include'ing `gb.h` from some external place.

I ran into a compiler error with this line and spent too much time debugging and understanding the code and compiler behavior before realizing what the problem was. Alternatives to this would be using the `c23` standard in the project instead, just typing `int` instead of using `typeof` or not guarding the define in defs.h behind `GB_INTERNAL`. I'm not making an issue for this because it's very easy to fix, just super annoying to stumble over (the compiler error message is NOT helpful).