### PR TITLE
Update GBViewController.m

### DIFF
--- a/iOS/GBViewController.m
+++ b/iOS/GBViewController.m
@@ -1245,6 +1245,7 @@ static void rumbleCallback(GB_gameboy_t *gb, double amp)
                                        32,
                                        32);
 
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations


### PR DESCRIPTION
`-[GBViewController didRotateFromInterfaceOrientation:]` seems to want `[super ...]` called to it, as Documentation says.

Also `[-didRotateFromInterfaceOrientation:] is deprecated, and that `viewWillTransitionToSize:withTransitionCoordinator:` is a replacement