### PR TITLE
Removal of cheats should be based on cheat_count, not gb_cheats

### DIFF
--- a/Core/cheats.c
+++ b/Core/cheats.c
@@ -143,7 +143,7 @@ void GB_remove_cheat(GB_gameboy_t *gb, const GB_cheat_t *cheat)
 
 void GB_remove_all_cheats(GB_gameboy_t *gb)
 {
-    while (gb->cheats) {
+    while (gb->cheat_count) {
         GB_remove_cheat(gb, gb->cheats[0]);
     }
 }


### PR DESCRIPTION
This is because we call free based on cheat_count, not if cheats is not null.