### PR TITLE
Core: Fix object_low_line_address masking in sanitize_state

### DIFF
--- a/Core/save_state.c
+++ b/Core/save_state.c
@@ -409,7 +409,7 @@ static void sanitize_state(GB_gameboy_t *gb)
         gb->current_tile_attributes = 0;
     }
 
-    gb->object_low_line_address &= gb->vram_size & ~1;
+    gb->object_low_line_address &= (gb->vram_size - 1) & ~1;
     if (gb->lcd_x > gb->position_in_line) {
         gb->lcd_x = gb->position_in_line;
     }


### PR DESCRIPTION
In sanitize_state, gb->object_low_line_address was incorrectly masked with gb->vram_size & ~1. If vram_size is 16KB (0x4000), this masks out all bits except bit 14, causing it to lose address bits and trigger out-of-bounds reads. Changed to mask with (gb->vram_size - 1) & ~1.